### PR TITLE
Feature/custom no results

### DIFF
--- a/src/components/search/src/components/DataGrid.test.js
+++ b/src/components/search/src/components/DataGrid.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import { mount } from 'enzyme';
+import { Map } from 'immutable';
+
+import { mockSearchResultsForPeople, mockResultLabels } from './constants';
+import DataGrid from './DataGrid';
+import Label from '../../../../label';
+import { Truncated } from './styled/StyledResultComponents';
+
+describe('DataGrid', () => {
+  describe('snapshots', () => {
+    test('should match snapshot', () => {
+      const data = mockSearchResultsForPeople.first();
+      const wrapper = mount(<DataGrid data={data} />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    test('should match snapshot with labels', () => {
+      const data = mockSearchResultsForPeople.first();
+      const wrapper = mount(<DataGrid data={data} labelMap={mockResultLabels} />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
+  describe('render', () => {
+    test('should only render data for labels with matching keys', () => {
+      const data = mockSearchResultsForPeople.first();
+      const customResultLabels = Map({
+        firstName: 'First Name',
+      });
+
+      const wrapper = mount(<DataGrid data={data} labelMap={customResultLabels} />);
+      expect(wrapper.find(Label)).toHaveLength(1);
+      expect(wrapper.find(Truncated)).toHaveLength(1);
+
+      expect(wrapper.find(Label).text()).toEqual(customResultLabels.get('firstName'));
+      expect(wrapper.find(Truncated).text()).toEqual(data.get('firstName'));
+    });
+
+    test('should render all data if labelMap not provided', () => {
+      const data = mockSearchResultsForPeople.first();
+
+      const wrapper = mount(<DataGrid data={data} />);
+      expect(wrapper.find(Label)).toHaveLength(data.count());
+      expect(wrapper.find(Truncated)).toHaveLength(data.count());
+    });
+  });
+
+});

--- a/src/components/search/src/components/Result.test.js
+++ b/src/components/search/src/components/Result.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import { mount } from 'enzyme';
+import { Map } from 'immutable';
+
+import Result from './Result';
+import {
+  mockSearchResultsForPeople,
+} from './constants';
+
+describe('Result', () => {
+  describe('snapshots', () => {
+
+    test('should match snapshot', () => {
+      const wrapper = mount(<Result result={Map()} />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+  });
+
+  describe('handleClick', () => {
+    test('should call handleClick', () => {
+      const mockResult = mockSearchResultsForPeople.first();
+      const wrapper = mount(<Result result={mockResult} />);
+      const instance = wrapper.instance();
+      const handleClickSpy = jest.spyOn(instance, 'handleClick');
+
+      instance.forceUpdate();
+      wrapper.find(Result).simulate('click');
+
+      expect(handleClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should call onClick with result', () => {
+      const mockResult = mockSearchResultsForPeople.first();
+      const mockOnClick = jest.fn();
+      const wrapper = mount(<Result result={mockResult} onClick={mockOnClick} />);
+
+      wrapper.simulate('click');
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+      expect(mockOnClick.mock.calls[0][0]).toEqual(mockSearchResultsForPeople.first());
+    });
+
+  });
+});

--- a/src/components/search/src/components/Search.js
+++ b/src/components/search/src/components/Search.js
@@ -21,6 +21,7 @@ import type { ReactSelectEvent, ReactSelectOption, ReactSelectValue } from '../.
 
 type Props = {
   className ? :string;
+  hasSearched ? :boolean;
   isLoading :any;
   filterFields ? :FilterFieldDefinition[];
   onResultClick ? :(result :Map) => void;
@@ -43,6 +44,7 @@ class Search extends Component<Props, State> {
   static defaultProps = {
     className: undefined,
     filterFields: [],
+    hasSearched: false,
     onResultClick: undefined,
     resultComponent: DefaultResultComponent,
     resultLabels: undefined,
@@ -113,6 +115,7 @@ class Search extends Component<Props, State> {
 
   renderFilteredSearchResults = () :Node => {
     const {
+      hasSearched,
       isLoading,
       filterFields,
       onResultClick,
@@ -152,6 +155,7 @@ class Search extends Component<Props, State> {
     if (SearchResultsComponent) {
       return (
         <SearchResultsComponent
+            hasSearched={hasSearched}
             isLoading={isLoading}
             onResultClick={onResultClick}
             resultComponent={resultComponent}

--- a/src/components/search/src/components/Search.test.js
+++ b/src/components/search/src/components/Search.test.js
@@ -160,8 +160,8 @@ describe('Search', () => {
       const instance = wrapper.instance();
 
       const changeValue = [{
-        label: 'Crisis Template',
-        value: 'Crisis Template'
+        label: 'Report #1',
+        value: 'Report #1'
       }];
       const changeEvent = { name: 'reportType' };
 
@@ -201,8 +201,8 @@ describe('Search', () => {
       const instance = wrapper.instance();
 
       const changeValue = [{
-        label: 'Crisis Template',
-        value: 'Crisis Template'
+        label: 'Report #1',
+        value: 'Report #1'
       }];
       const changeEvent = { name: 'reportType' };
       instance.handleOnChangeFilter(changeValue, changeEvent);
@@ -221,7 +221,7 @@ describe('Search', () => {
       const instance = wrapper.instance();
 
       let changeValue = [{
-        value: 'Crisis Template'
+        value: 'Report #1'
       }];
       let changeEvent = { name: 'reportType' };
       // apply one filter
@@ -264,7 +264,7 @@ describe('Search', () => {
       const instance = wrapper.instance();
 
       const changeValue = [{
-        value: 'Crisis Template'
+        value: 'Report #1'
       }];
       const changeEvent = { name: 'BaDFiLtErDefiNiTioN' };
       instance.handleOnChangeFilter(changeValue, changeEvent);

--- a/src/components/search/src/components/Search.test.js
+++ b/src/components/search/src/components/Search.test.js
@@ -181,6 +181,37 @@ describe('Search', () => {
       expect(instance.renderFilteredSearchResults()).toEqual(null);
     });
 
+    test('should not filter results if invalid searchResults', () => {
+      const wrapper = shallow(
+        <Search
+            searchResults={false} />
+      );
+
+      const filteredResults = wrapper.find(SearchResults).props().results;
+      expect(List.isList(filteredResults)).toEqual(true);
+      expect(filteredResults.count()).toEqual(0);
+    });
+
+    test('should not filter results if invalid filterFields', () => {
+      const wrapper = shallow(
+        <Search
+            searchResults={mockSearchResultsForReports}
+            filterFields={false} />
+      );
+      const instance = wrapper.instance();
+
+      const changeValue = [{
+        label: 'Crisis Template',
+        value: 'Crisis Template'
+      }];
+      const changeEvent = { name: 'reportType' };
+      instance.handleOnChangeFilter(changeValue, changeEvent);
+
+      const filteredResults = wrapper.find(SearchResults).props().results;
+      expect(List.isList(filteredResults)).toEqual(true);
+      expect(filteredResults).toEqual(mockSearchResultsForReports);
+    });
+
     test('should filter results', () => {
       const wrapper = shallow(
         <Search
@@ -281,6 +312,18 @@ describe('Search', () => {
 
   describe('onResultClick', () => {
     test('should call onResultClick with result', () => {
+      const mockOnResultClick = jest.fn();
+      const wrapper = mount(<Search onResultClick={mockOnResultClick} searchResults={mockSearchResultsForPeople} />);
+
+      const resultWrapper = wrapper.find('Result').first();
+      expect(resultWrapper).toHaveLength(1);
+
+      resultWrapper.simulate('click');
+      expect(mockOnResultClick).toHaveBeenCalledTimes(1);
+      expect(mockOnResultClick.mock.calls[0][0]).toEqual(mockSearchResultsForPeople.first());
+    });
+
+    test('should not call onResultClick if onClick is not a function', () => {
       const mockOnResultClick = jest.fn();
       const wrapper = mount(<Search onResultClick={mockOnResultClick} searchResults={mockSearchResultsForPeople} />);
 

--- a/src/components/search/src/components/SearchResults.js
+++ b/src/components/search/src/components/SearchResults.js
@@ -6,22 +6,29 @@ import { List, Map } from 'immutable';
 
 import NotFound from './NotFound';
 import Result from './Result';
+import Spinner from '../../../../spinner';
 import { CardStack } from '../../../../layout';
 
 import type { ResultProps } from './Result';
 
 type Props = {
-  results :List<Map>;
-  resultLabels ? :Map;
-  resultComponent ? :ComponentType<ResultProps>;
   className ? :string;
+  hasSearched ? :boolean;
+  isLoading ? :boolean;
+  noResults ? :ComponentType<any>;
   onResultClick ? :(result :Map) => void;
+  resultComponent ? :ComponentType<ResultProps>;
+  resultLabels ? :Map;
+  results :List<Map>;
 };
 
 class SearchResults extends Component<Props> {
 
   static defaultProps = {
     className: undefined,
+    hasSearched: false,
+    isLoading: false,
+    noResults: () => (<NotFound caption="No results" />),
     onResultClick: undefined,
     resultComponent: Result,
     resultLabels: undefined,
@@ -29,11 +36,17 @@ class SearchResults extends Component<Props> {
 
   renderResults = () :Node => {
     const {
+      hasSearched,
+      isLoading,
+      noResults: NoResults,
       onResultClick,
       resultComponent: ResultComponent,
       resultLabels,
       results,
     } = this.props;
+
+    if (isLoading) return <Spinner size="2x" />;
+
     if (List.isList(results) && results.count() && ResultComponent) {
       return results.map((result :Map, index :number) => (
         <ResultComponent
@@ -44,7 +57,11 @@ class SearchResults extends Component<Props> {
       ));
     }
 
-    return <NotFound caption="No results" />;
+    if (hasSearched && NoResults) {
+      return <NoResults />;
+    }
+
+    return null;
   }
 
   render() {

--- a/src/components/search/src/components/SearchResults.test.js
+++ b/src/components/search/src/components/SearchResults.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import { mount, shallow } from 'enzyme';
+import { List } from 'immutable';
+
+import SearchResults from './SearchResults';
+import PersonResult from './PersonResult';
+import Result from './Result';
+import {
+  mockSearchResultsForPeople,
+} from './constants';
+import Spinner from '../../../../spinner';
+import NotFound from './NotFound';
+
+describe('SearchResults', () => {
+
+  describe('snapshots', () => {
+    test('should match snapshot', () => {
+      const wrapper = mount(<SearchResults />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
+  describe('props', () => {
+
+    test('should render custom ResultComponents', () => {
+      const wrapper = mount(
+        <SearchResults
+            results={mockSearchResultsForPeople}
+            resultComponent={PersonResult} />
+      );
+      expect(wrapper.find(PersonResult)).toHaveLength(3);
+    });
+
+    test('should render default Result when provided searchResults', () => {
+      const wrapper = mount(<SearchResults results={mockSearchResultsForPeople} />);
+      expect(wrapper.find(Result)).toHaveLength(3);
+    });
+
+    test('should render Spinner when isLoading', () => {
+      const wrapper = shallow(<SearchResults isLoading />);
+      expect(wrapper.find(Spinner)).toHaveLength(1);
+    });
+
+    test('should render default noResult when hasSearched and results are empty', () => {
+      const wrapper = mount(<SearchResults hasSearched results={List()} />);
+      expect(wrapper.find(NotFound)).toHaveLength(1);
+    });
+
+    test('should render custom noResult when hasSearched and results are empty', () => {
+      const customNoResults = () => (<div>I am custom</div>);
+      const wrapper = mount(<SearchResults hasSearched results={List()} noResults={customNoResults} />);
+      expect(wrapper.find(customNoResults)).toHaveLength(1);
+    });
+
+  });
+
+});

--- a/src/components/search/src/components/__snapshots__/DataGrid.test.js.snap
+++ b/src/components/search/src/components/__snapshots__/DataGrid.test.js.snap
@@ -1,0 +1,1439 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataGrid snapshots should match snapshot 1`] = `
+.c0 {
+  display: grid;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  grid-auto-flow: row;
+  grid-template-columns: repeat(4,minmax(0,1fr));
+  grid-gap: 20px 30px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 {
+  color: #555e6f;
+  display: inline-block;
+  font-size: 14px;
+  font-stretch: normal;
+  font-style: normal;
+  font-weight: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  margin: 5px 5px 5px 0;
+  color: #8e929b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+<DataGrid
+  columns={4}
+  data={
+    Immutable.Map {
+      "lastName": "Werbenjagermanjensen",
+      "firstName": "Smitty",
+      "middleName": "",
+      "sex": "M",
+      "gender": "M",
+      "ethnicity": "Fish",
+      "dob": "02/22/2002",
+      "identifier": "365ba027-0c71-47d1-a5f4-61346ed96d8c",
+    }
+  }
+  emptyString="---"
+>
+  <StyledResultComponents__ResultGrid
+    columns={4}
+  >
+    <StyledComponent
+      columns={4}
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "StyledResultComponents__ResultGrid-drevdl-0",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              "display:grid;flex:1;grid-auto-flow:row;grid-template-columns:",
+              [Function],
+              ";grid-gap:20px 30px;",
+            ],
+          },
+          "displayName": "StyledResultComponents__ResultGrid",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "StyledResultComponents__ResultGrid-drevdl-0",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+    >
+      <div
+        className="c0"
+      >
+        <div
+          key="0"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                lastName
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                Werbenjagermanjensen
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="1"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                firstName
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                Smitty
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="2"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                middleName
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              />
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="3"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                sex
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                M
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="4"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                gender
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                M
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="5"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                ethnicity
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                Fish
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="6"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                dob
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                02/22/2002
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="7"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                identifier
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                365ba027-0c71-47d1-a5f4-61346ed96d8c
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+      </div>
+    </StyledComponent>
+  </StyledResultComponents__ResultGrid>
+</DataGrid>
+`;
+
+exports[`DataGrid snapshots should match snapshot with labels 1`] = `
+.c0 {
+  display: grid;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  grid-auto-flow: row;
+  grid-template-columns: repeat(4,minmax(0,1fr));
+  grid-gap: 20px 30px;
+}
+
+.c2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 {
+  color: #555e6f;
+  display: inline-block;
+  font-size: 14px;
+  font-stretch: normal;
+  font-style: normal;
+  font-weight: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  margin: 5px 5px 5px 0;
+  color: #8e929b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+<DataGrid
+  columns={4}
+  data={
+    Immutable.Map {
+      "lastName": "Werbenjagermanjensen",
+      "firstName": "Smitty",
+      "middleName": "",
+      "sex": "M",
+      "gender": "M",
+      "ethnicity": "Fish",
+      "dob": "02/22/2002",
+      "identifier": "365ba027-0c71-47d1-a5f4-61346ed96d8c",
+    }
+  }
+  emptyString="---"
+  labelMap={
+    Immutable.Map {
+      "lastName": "Last name",
+      "firstName": "First name",
+      "middleName": "Middle name",
+      "sex": "Sex",
+      "gender": "Gender",
+      "ethnicity": "Ethnicity",
+      "dob": "DOB",
+      "identifier": "Identifier",
+    }
+  }
+>
+  <StyledResultComponents__ResultGrid
+    columns={4}
+  >
+    <StyledComponent
+      columns={4}
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "StyledResultComponents__ResultGrid-drevdl-0",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              "display:grid;flex:1;grid-auto-flow:row;grid-template-columns:",
+              [Function],
+              ";grid-gap:20px 30px;",
+            ],
+          },
+          "displayName": "StyledResultComponents__ResultGrid",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "StyledResultComponents__ResultGrid-drevdl-0",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+    >
+      <div
+        className="c0"
+      >
+        <div
+          key="0"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                Last name
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                Werbenjagermanjensen
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="1"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                First name
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                Smitty
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="2"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                Middle name
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              />
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="3"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                Sex
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                M
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="4"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                Gender
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                M
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="5"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                Ethnicity
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                Fish
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="6"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                DOB
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                02/22/2002
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+        <div
+          key="7"
+        >
+          <Label
+            subtle={true}
+          >
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Label-sc-130fyca-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "color:",
+                      "#555e6f",
+                      ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                      [Function],
+                      ";letter-spacing:normal;margin:5px 5px 5px 0;",
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Label",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Label-sc-130fyca-0",
+                  "target": "label",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+              subtle={true}
+            >
+              <label
+                className="c1"
+              >
+                Identifier
+              </label>
+            </StyledComponent>
+          </Label>
+          <StyledResultComponents__Truncated>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "StyledResultComponents__Truncated-drevdl-3",
+                    "isStatic": true,
+                    "lastClassName": "c2",
+                    "rules": Array [
+                      "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                    ],
+                  },
+                  "displayName": "StyledResultComponents__Truncated",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "StyledResultComponents__Truncated-drevdl-3",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c2"
+              >
+                365ba027-0c71-47d1-a5f4-61346ed96d8c
+              </div>
+            </StyledComponent>
+          </StyledResultComponents__Truncated>
+        </div>
+      </div>
+    </StyledComponent>
+  </StyledResultComponents__ResultGrid>
+</DataGrid>
+`;

--- a/src/components/search/src/components/__snapshots__/Result.test.js.snap
+++ b/src/components/search/src/components/__snapshots__/Result.test.js.snap
@@ -1,0 +1,233 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Result snapshots should match snapshot 1`] = `
+.c3 {
+  display: grid;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  grid-auto-flow: row;
+  grid-template-columns: repeat(4,minmax(0,1fr));
+  grid-gap: 20px 30px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 10px;
+}
+
+.c2 {
+  padding: 10px 30px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c0 {
+  background-color: #ffffff;
+  border: 1px solid #dcdce7;
+  border-radius: 5px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+}
+
+.c0 > div {
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c0 > div:first-child {
+  border-radius: 5px 5px 0 0;
+}
+
+.c0 > div:last-child {
+  border-bottom: 0;
+  border-radius: 0 0 5px 5px;
+}
+
+.c0:hover {
+  box-shadow: 0 2px 8px -2px rgba(0,0,0,0.15);
+  cursor: pointer;
+}
+
+.c0:hover * {
+  cursor: inherit;
+  pointer-events: auto;
+}
+
+.c0:active {
+  box-shadow: none;
+}
+
+<Result
+  result={Immutable.Map {}}
+  resultColumns={4}
+>
+  <Card
+    onClick={[Function]}
+  >
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "Card-sc-3vnjrr-0",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              "background-color:",
+              "#ffffff",
+              ";border:1px solid ",
+              "#dcdce7",
+              ";border-radius:5px;display:flex;flex:0 0 auto;flex-direction:column;position:relative;& > div{border-bottom:1px solid ",
+              "#dcdce7",
+              ";}& > div:first-child{border-radius:5px 5px 0 0;}& > div:last-child{border-bottom:0;border-radius:0 0 5px 5px;}",
+              [Function],
+              ";",
+            ],
+          },
+          "displayName": "Card",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "Card-sc-3vnjrr-0",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      onClick={[Function]}
+    >
+      <div
+        className="c0"
+        onClick={[Function]}
+      >
+        <StyledResultComponents__ResultWrapper>
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "StyledResultComponents__ResultWrapper-drevdl-1",
+                  "isStatic": true,
+                  "lastClassName": "c1",
+                  "rules": Array [
+                    "display:flex;flex-direction:row;padding:10px;",
+                  ],
+                },
+                "displayName": "StyledResultComponents__ResultWrapper",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "StyledResultComponents__ResultWrapper-drevdl-1",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+          >
+            <div
+              className="c1"
+            >
+              <StyledResultComponents__ResultDetails>
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "StyledResultComponents__ResultDetails-drevdl-2",
+                        "isStatic": true,
+                        "lastClassName": "c2",
+                        "rules": Array [
+                          "padding:10px 30px;flex:1;",
+                        ],
+                      },
+                      "displayName": "StyledResultComponents__ResultDetails",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "StyledResultComponents__ResultDetails-drevdl-2",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                >
+                  <div
+                    className="c2"
+                  >
+                    <DataGrid
+                      columns={4}
+                      data={Immutable.Map {}}
+                      emptyString="---"
+                    >
+                      <StyledResultComponents__ResultGrid
+                        columns={4}
+                      >
+                        <StyledComponent
+                          columns={4}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "StyledResultComponents__ResultGrid-drevdl-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "display:grid;flex:1;grid-auto-flow:row;grid-template-columns:",
+                                  [Function],
+                                  ";grid-gap:20px 30px;",
+                                ],
+                              },
+                              "displayName": "StyledResultComponents__ResultGrid",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "StyledResultComponents__ResultGrid-drevdl-0",
+                              "target": "div",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <div
+                            className="c3"
+                          >
+                            <Component />
+                          </div>
+                        </StyledComponent>
+                      </StyledResultComponents__ResultGrid>
+                    </DataGrid>
+                  </div>
+                </StyledComponent>
+              </StyledResultComponents__ResultDetails>
+            </div>
+          </StyledComponent>
+        </StyledResultComponents__ResultWrapper>
+      </div>
+    </StyledComponent>
+  </Card>
+</Result>
+`;

--- a/src/components/search/src/components/__snapshots__/Search.test.js.snap
+++ b/src/components/search/src/components/__snapshots__/Search.test.js.snap
@@ -70,6 +70,9 @@ exports[`Search snapshots should match snapshot 1`] = `
     </CardSegment>
   </Card>
   <SearchResults
+    hasSearched={false}
+    isLoading={false}
+    noResults={[Function]}
     resultComponent={[Function]}
     results={Immutable.List []}
   />

--- a/src/components/search/src/components/__snapshots__/SearchResults.test.js.snap
+++ b/src/components/search/src/components/__snapshots__/SearchResults.test.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchResults snapshots should match snapshot 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+}
+
+.c0 > div {
+  margin: 10px 0;
+}
+
+.c0 > div:first-child {
+  margin-top: 0;
+}
+
+.c0 > div:last-child {
+  margin-bottom: 0;
+}
+
+<SearchResults
+  hasSearched={false}
+  isLoading={false}
+  noResults={[Function]}
+  resultComponent={[Function]}
+>
+  <CardStack>
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "CardStack-sc-1vtkaja-0",
+            "isStatic": true,
+            "lastClassName": "c0",
+            "rules": Array [
+              "display:flex;flex-direction:column;position:relative;& > div{margin:10px 0;}& > div:first-child{margin-top:0;}& > div:last-child{margin-bottom:0;}",
+            ],
+          },
+          "displayName": "CardStack",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "CardStack-sc-1vtkaja-0",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+    >
+      <div
+        className="c0"
+      />
+    </StyledComponent>
+  </CardStack>
+</SearchResults>
+`;

--- a/src/components/search/src/components/constants.js
+++ b/src/components/search/src/components/constants.js
@@ -22,7 +22,7 @@ const mockFilterFields :FilterFieldDefinition[] = [
     },
     id: 'reportType',
     label: 'Report type',
-    options: ['Crisis Template', 'Follow-up'],
+    options: ['Report #1', 'Report #2'],
   },
   {
     filterCallback: (searchResult :Map, filterValues :ReactSelectValue) => {
@@ -39,7 +39,7 @@ const mockFilterFields :FilterFieldDefinition[] = [
     },
     id: 'badges',
     label: 'Badges',
-    options: ['Officer Safety', 'Substance use'],
+    options: ['Badge #1', 'Badge #2'],
   },
   {
     filterCallback: (searchResult :Map, filterValues :ReactSelectValue) => {
@@ -67,32 +67,32 @@ const mockFilterFields :FilterFieldDefinition[] = [
 
 const mockSearchResultsForReports = List([
   Map({
-    reportType: 'Crisis Template',
-    badges: ['Officer Safety'],
+    reportType: 'Report #1',
+    badges: ['Badge #1'],
     submitter: 'squidward@bubblebowl.com'
   }),
   Map({
-    reportType: 'Follow-up',
-    badges: ['Officer Safety', 'Substance use'],
+    reportType: 'Report #2',
+    badges: ['Badge #1', 'Badge #2'],
     submitter: 'squidward@bubblebowl.com',
   }),
   Map({
-    reportType: 'Crisis Template',
-    badges: ['Officer Safety', 'Substance use'],
+    reportType: 'Report #1',
+    badges: ['Badge #1', 'Badge #2'],
     submitter: 'smitty@werbenjagermanjensen.com'
   }),
   Map({
-    reportType: 'Follow-up',
-    badges: ['Substance use'],
+    reportType: 'Report #2',
+    badges: ['Badge #2'],
     submitter: 'wumbology@thestudyofwumbo.com'
   }),
   Map({
-    reportType: 'Crisis Template',
-    badges: ['Officer Safety', 'Substance use'],
+    reportType: 'Report #1',
+    badges: ['Badge #1', 'Badge #2'],
     submitter: 'enigma@innermachinations.com'
   }),
   Map({
-    reportType: 'Follow-up',
+    reportType: 'Report #2',
     submitter: 'enigma@innermachinations.com'
   }),
 ]);

--- a/src/components/search/src/components/styled/StyledSearchComponents.js
+++ b/src/components/search/src/components/styled/StyledSearchComponents.js
@@ -7,7 +7,7 @@ type InputGridProps = {
 }
 
 const getGridTemplateColumns = ({ columns = 4 } :InputGridProps) => css`
-  grid-template-columns: repeat(${columns}, minmax(100px, 1fr));
+  grid-template-columns: repeat(${columns}, minmax(0, 1fr));
 `;
 
 const getAlignItems = ({ align } :InputGridProps) => css`

--- a/src/components/search/stories/components/SearchContainer.js
+++ b/src/components/search/stories/components/SearchContainer.js
@@ -57,6 +57,7 @@ class SearchContainer extends Component<Props, State> {
               submitter: 'Submitter'
             }}
             filterFields={mockFilterFields}
+            hasSearched={fetchState !== 'STANDBY'}
             isLoading={fetchState === 'PENDING'}
             onSearch={this.handleOnSearch}
             searchResults={results}

--- a/src/spinner/src/components/Spinner.js
+++ b/src/spinner/src/components/Spinner.js
@@ -9,6 +9,8 @@ import { NEUTRALS } from '../../../colors';
 type Props = {
   /** color of spinner circle */
   bottomColor ? :string;
+  /** set align-self to center or flex-start */
+  centered ? :boolean;
   /** React component className */
   className ? :string;
   /** animation duration */
@@ -22,6 +24,7 @@ type Props = {
 const Spinner = (props :Props) => {
   const {
     bottomColor,
+    centered,
     className,
     duration,
     size,
@@ -34,7 +37,7 @@ const Spinner = (props :Props) => {
   const styledClassName = className ? `${defaultClassName} ${className}` : defaultClassName;
 
   return (
-    <Rotate className={styledClassName} duration={duration}>
+    <Rotate className={styledClassName} duration={duration} centered={centered}>
       <FontAwesomeIcon
           id="spinner-circle"
           color={bottomColor}
@@ -50,8 +53,9 @@ const Spinner = (props :Props) => {
 
 Spinner.defaultProps = {
   bottomColor: NEUTRALS[3],
+  centered: true,
   className: undefined,
-  duration: '0.75s',
+  duration: undefined,
   size: '1x',
   topColor: NEUTRALS[0],
 };

--- a/src/spinner/src/components/Spinner.test.js
+++ b/src/spinner/src/components/Spinner.test.js
@@ -11,6 +11,17 @@ describe('Spinner', () => {
   });
 
   describe('styles', () => {
+
+    test('should set align-self to "center" by default', () => {
+      const wrapper = mount(<Spinner />);
+      expect(wrapper.find('Rotate')).toHaveStyleRule('align-self', 'center');
+    });
+
+    test('should set align-self to "flex-start" if centered is false', () => {
+      const wrapper = mount(<Spinner centered={false} />);
+      expect(wrapper.find('Rotate')).toHaveStyleRule('align-self', 'flex-start');
+    });
+
     test('should pass bottomColor prop to spinner circle', () => {
       const newColor = 'rebeccapurple';
       const wrapper = shallow(<Spinner bottomColor={newColor} />);
@@ -23,11 +34,18 @@ describe('Spinner', () => {
       expect(wrapper.find('FontAwesomeIcon#spinner-third').props().color).toEqual(newColor);
     });
 
+    test('should set duration of Rotate animation to 0.75s by default', () => {
+      const defaultDuration = '0.75s';
+      const wrapper = mount(<Spinner />);
+      expect(wrapper.find('Rotate').props().duration).toEqual(undefined);
+      expect(wrapper.find('Rotate')).toHaveStyleRule('animation', `fa-spin ${defaultDuration} infinite linear`);
+    });
+
     test('should pass duration prop to Rotate', () => {
       const duration = '2s';
-      const wrapper = shallow(<Spinner duration={duration} />);
+      const wrapper = mount(<Spinner duration={duration} />);
       expect(wrapper.find('Rotate').props().duration).toEqual(duration);
-      expect(wrapper.find('Rotate').props().duration).toEqual(duration);
+      expect(wrapper.find('Rotate')).toHaveStyleRule('animation', `fa-spin ${duration} infinite linear`);
     });
 
     test('should adjust fa-{size} className', () => {

--- a/src/spinner/src/components/__snapshots__/Spinner.test.js.snap
+++ b/src/spinner/src/components/__snapshots__/Spinner.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`Spinner snapshot 1`] = `
 <Rotate
+  centered={true}
   className="fa-layers fa-fw fa-1x"
-  duration="0.75s"
 >
   <FontAwesomeIcon
     border={false}

--- a/src/spinner/src/components/styled/Rotate.js
+++ b/src/spinner/src/components/styled/Rotate.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const Rotate = styled.span`
   animation: fa-spin ${({ duration }) => (duration || '0.75s')} infinite linear;
+  align-self: ${({ centered }) => (centered ? 'center' : 'flex-start')};
 `;
 
 export default Rotate;


### PR DESCRIPTION
SearchResults now only renders `NoResults` component prop if `hasSearched` prop is true. Renders Spinner of size 2x when `isLoading` is true.

Adds miscellaneous unit test coverage 