### PR TITLE
react and react-dom are externals

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -63,6 +63,18 @@ module.exports = (env = {}) => {
       LIB_PATHS.ABS.ENTRY,
     ],
     externals: {
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react'
+      },
+      'react-dom': {
+        root: 'ReactDOM',
+        commonjs2: 'react-dom',
+        commonjs: 'react-dom',
+        amd: 'react-dom'
+      },
       'styled-components': {
         amd: 'styled-components',
         commonjs: 'styled-components',


### PR DESCRIPTION
https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react

This change defines `react` and `react-dom` as external dependencies to avoid a copy of react from being included in LUK. The correct version of these packages are listed as peerDependencies.

This should resolve the following error from being thrown when using hooks.
https://reactjs.org/docs/error-decoder.html/?invariant=321