### PR TITLE
Fix/revert row key

### DIFF
--- a/src/table/src/components/TableBody.js
+++ b/src/table/src/components/TableBody.js
@@ -60,13 +60,12 @@ const TableBody = (props :Props) => {
   return (
     <tbody className={className}>
       {
-        dataByPage.map((rowData :RowData, index) => {
+        dataByPage.map((rowData :RowData) => {
 
           const { id } = rowData;
-          const key = `row${index}-id${id}`;
           return (
             <components.Row
-                key={key}
+                key={id}
                 data={rowData}
                 headers={headers}
                 components={components} />

--- a/src/table/src/components/__snapshots__/TableBody.test.js.snap
+++ b/src/table/src/components/__snapshots__/TableBody.test.js.snap
@@ -89,7 +89,7 @@ exports[`TableBody render should render tbody at root 1`] = `
         },
       ]
     }
-    key="row0-id1"
+    key="1"
   />
   <TableRow
     components={
@@ -153,7 +153,7 @@ exports[`TableBody render should render tbody at root 1`] = `
         },
       ]
     }
-    key="row1-id2"
+    key="2"
   />
   <TableRow
     components={
@@ -217,7 +217,7 @@ exports[`TableBody render should render tbody at root 1`] = `
         },
       ]
     }
-    key="row2-id3"
+    key="3"
   />
   <TableRow
     components={
@@ -281,7 +281,7 @@ exports[`TableBody render should render tbody at root 1`] = `
         },
       ]
     }
-    key="row3-id4"
+    key="4"
   />
   <TableRow
     components={
@@ -345,7 +345,7 @@ exports[`TableBody render should render tbody at root 1`] = `
         },
       ]
     }
-    key="row4-id5"
+    key="5"
   />
   <TableRow
     components={
@@ -409,7 +409,7 @@ exports[`TableBody render should render tbody at root 1`] = `
         },
       ]
     }
-    key="row5-id6"
+    key="6"
   />
   <TableRow
     components={
@@ -473,7 +473,7 @@ exports[`TableBody render should render tbody at root 1`] = `
         },
       ]
     }
-    key="row6-id7"
+    key="7"
   />
   <styled__StyledRow
     id="empty-row-filler"


### PR DESCRIPTION
Remove index from key. This is causing unnecessary re-renders when row order has changed. Much better practice to ensure that the id passed is unique and stable.