### PR TITLE
Fix/icon splash style

### DIFF
--- a/src/components/search/src/components/IconSplash.js
+++ b/src/components/search/src/components/IconSplash.js
@@ -8,6 +8,9 @@ import type { ComponentType } from 'react';
 import { NEUTRALS } from '../../../../colors';
 
 const FigureWrapper = styled.figure`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   margin: 10px auto;
   text-align: center;
 

--- a/src/components/search/src/components/IconSplash.js
+++ b/src/components/search/src/components/IconSplash.js
@@ -11,6 +11,10 @@ const FigureWrapper = styled.figure`
   margin: 10px auto;
   text-align: center;
 
+  > div:first-child {
+    margin-bottom: 10px;
+  }
+
   figcaption {
     color: ${NEUTRALS[1]};
     font-size: 16px;
@@ -41,11 +45,10 @@ class IconSplash extends Component<Props> {
   renderIcon = () => {
     const { icon, size } = this.props;
     if (icon) {
-      if (typeof icon === 'function') {
-        return icon(size);
-      }
-
-      return <FontAwesomeIcon icon={icon} size={size} fixedWidth />;
+      const content = typeof icon === 'function'
+        ? icon(size)
+        : <FontAwesomeIcon icon={icon} size={size} fixedWidth />;
+      return <div>{content}</div>;
     }
     return null;
   }

--- a/src/components/search/src/components/__snapshots__/IconSplash.test.js.snap
+++ b/src/components/search/src/components/__snapshots__/IconSplash.test.js.snap
@@ -2,36 +2,38 @@
 
 exports[`IconSplash should match snapshot 1`] = `
 <IconSplash__FigureWrapper>
-  <FontAwesomeIcon
-    border={false}
-    className=""
-    fixedWidth={true}
-    flip={null}
-    icon={
-      Object {
-        "icon": Array [
-          512,
-          512,
-          Array [],
-          "f010",
-          "M312 196v24c0 6.6-5.4 12-12 12H116c-6.6 0-12-5.4-12-12v-24c0-6.6 5.4-12 12-12h184c6.6 0 12 5.4 12 12zm196.5 289.9l-22.6 22.6c-4.7 4.7-12.3 4.7-17 0L347.5 387.1c-2.3-2.3-3.5-5.3-3.5-8.5v-13.2c-36.5 31.5-84 50.6-136 50.6C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 52-19.1 99.5-50.6 136h13.2c3.2 0 6.2 1.3 8.5 3.5l121.4 121.4c4.7 4.7 4.7 12.3 0 17zM368 208c0-88.4-71.6-160-160-160S48 119.6 48 208s71.6 160 160 160 160-71.6 160-160z",
-        ],
-        "iconName": "search-minus",
-        "prefix": "far",
+  <div>
+    <FontAwesomeIcon
+      border={false}
+      className=""
+      fixedWidth={true}
+      flip={null}
+      icon={
+        Object {
+          "icon": Array [
+            512,
+            512,
+            Array [],
+            "f010",
+            "M312 196v24c0 6.6-5.4 12-12 12H116c-6.6 0-12-5.4-12-12v-24c0-6.6 5.4-12 12-12h184c6.6 0 12 5.4 12 12zm196.5 289.9l-22.6 22.6c-4.7 4.7-12.3 4.7-17 0L347.5 387.1c-2.3-2.3-3.5-5.3-3.5-8.5v-13.2c-36.5 31.5-84 50.6-136 50.6C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 52-19.1 99.5-50.6 136h13.2c3.2 0 6.2 1.3 8.5 3.5l121.4 121.4c4.7 4.7 4.7 12.3 0 17zM368 208c0-88.4-71.6-160-160-160S48 119.6 48 208s71.6 160 160 160 160-71.6 160-160z",
+          ],
+          "iconName": "search-minus",
+          "prefix": "far",
+        }
       }
-    }
-    inverse={false}
-    listItem={false}
-    mask={null}
-    pull={null}
-    pulse={false}
-    rotation={null}
-    size="5x"
-    spin={false}
-    symbol={false}
-    title=""
-    transform={null}
-  />
+      inverse={false}
+      listItem={false}
+      mask={null}
+      pull={null}
+      pulse={false}
+      rotation={null}
+      size="5x"
+      spin={false}
+      symbol={false}
+      title=""
+      transform={null}
+    />
+  </div>
   <figcaption />
 </IconSplash__FigureWrapper>
 `;


### PR DESCRIPTION
IconSplash is now also vertically centered in addition to being horizontally centered

example:
![image](https://user-images.githubusercontent.com/27182199/66246625-3c3e2a00-e6ca-11e9-944f-764f2f963e4b.png)
