### PR TITLE
Fix/invalid datetime behavior

### DIFF
--- a/src/datetime/src/components/DatePicker.js
+++ b/src/datetime/src/components/DatePicker.js
@@ -30,23 +30,32 @@ const DatePicker = (props :Props) => {
   } = props;
 
   const [selectedDate, setSelectedDate] = useState(null);
+  const [lastValidDate, setLastValidDate] = useState(null);
 
   useEffect(() => {
     const date = DateTime.fromISO(value);
     if (date.isValid) {
       setSelectedDate(date);
+      setLastValidDate(date);
+    }
+    else {
+      setSelectedDate(null);
+      setLastValidDate(null);
     }
   }, [value]);
 
-  const InputProps = useInputPropsMemo();
+  const inputProps = useInputPropsMemo(lastValidDate, setSelectedDate);
 
   const handleDateChange = useCallback<DateChange>((date) => {
     if (isFunction(onChange)) {
-      if (date === null || !date.isValid) {
-        onChange('');
+      if (date === null) {
+        onChange();
+        setLastValidDate(null);
       }
-      else {
-        onChange(date.toISODate());
+      if (date && date.isValid) {
+        const dateIso = date.toISODate();
+        onChange(dateIso);
+        setLastValidDate(date);
       }
     }
     setSelectedDate(date);
@@ -58,7 +67,7 @@ const DatePicker = (props :Props) => {
         <KeyboardDatePicker
             disabled={disabled}
             format={format}
-            InputProps={InputProps}
+            InputProps={inputProps}
             inputVariant="outlined"
             mask={mask}
             onChange={handleDateChange}

--- a/src/datetime/src/components/DatePicker.test.js
+++ b/src/datetime/src/components/DatePicker.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { DateTime } from 'luxon';
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
@@ -19,7 +20,7 @@ describe('DatePicker', () => {
 
   describe('onChange', () => {
 
-    test('null or invalid date calls onChange with empty string', () => {
+    test('null calls onChange with undefined', () => {
       const mockOnChange = jest.fn();
       const wrapper = shallow(<DatePicker onChange={mockOnChange} />);
 
@@ -28,11 +29,19 @@ describe('DatePicker', () => {
 
       innerChange(null);
       expect(mockOnChange).toHaveBeenCalledTimes(1);
-      expect(mockOnChange.mock.calls[0][0]).toEqual('');
+      expect(mockOnChange.mock.calls[0][0]).toEqual();
+      expect(wrapper.find(KeyboardDatePicker).prop('value')).toEqual(null);
+    });
+
+    test('invalid date does not call onChange', () => {
+      const mockOnChange = jest.fn();
+      const wrapper = shallow(<DatePicker onChange={mockOnChange} />);
+
+      expect(mockOnChange).toHaveBeenCalledTimes(0);
+      const innerChange = wrapper.find(KeyboardDatePicker).prop('onChange');
 
       innerChange(invalidDate);
-      expect(mockOnChange).toHaveBeenCalledTimes(2);
-      expect(mockOnChange.mock.calls[1][0]).toEqual('');
+      expect(mockOnChange).toHaveBeenCalledTimes(0);
     });
 
     test('valid date calls onChange with ISO date string', () => {
@@ -45,6 +54,7 @@ describe('DatePicker', () => {
       innerChange(validDate);
       expect(mockOnChange).toHaveBeenCalledTimes(1);
       expect(mockOnChange.mock.calls[0][0]).toEqual(validDate.toISODate());
+      expect(wrapper.find(KeyboardDatePicker).prop('value')).toEqual(validDate);
     });
   });
 
@@ -60,26 +70,34 @@ describe('DatePicker', () => {
     });
   });
 
-  describe('input should preventDefault onKeyPress only for Enter', () => {
-    const preventDefault = jest.fn();
-    const wrapper = mount(<DatePicker />);
-    const input = wrapper.find('input');
+  describe('InputProps', () => {
+    test('input should preventDefault only for Enter keyPress', () => {
+      const preventDefault = jest.fn();
+      const wrapper = mount(<DatePicker />);
+      const input = wrapper.find('input');
 
-    expect(preventDefault).toHaveBeenCalledTimes(0);
+      expect(preventDefault).toHaveBeenCalledTimes(0);
 
-    input.simulate('keyDown', {
-      preventDefault,
-      key: 'Enter'
+      input.simulate('keyDown', {
+        preventDefault,
+        key: 'Enter'
+      });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+
+      input.simulate('keyDown', {
+        preventDefault,
+        key: 'Escape'
+      });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
     });
 
-    expect(preventDefault).toHaveBeenCalledTimes(1);
+    test('inner input should have onBlur', () => {
+      const wrapper = mount(<DatePicker />);
 
-    input.simulate('keyDown', {
-      preventDefault,
-      key: 'Escape'
+      expect(typeof wrapper.find('input').prop('onBlur')).toEqual('function');
     });
-
-    expect(preventDefault).toHaveBeenCalledTimes(1);
   });
 
 });

--- a/src/datetime/src/components/DatePicker.test.js
+++ b/src/datetime/src/components/DatePicker.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { DateTime } from 'luxon';
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';

--- a/src/datetime/src/components/DateTimePicker.js
+++ b/src/datetime/src/components/DateTimePicker.js
@@ -9,7 +9,7 @@ import LatticeLuxonUtils from './utils/LatticeLuxonUtils';
 import { latticeMuiTheme } from './styles';
 import useInputPropsMemo from './hooks/useInputPropsMemo';
 
-type DateTimeChange = (datetime :DateTime, value :string | null) => void;
+type DateChange = (datetime :DateTime, value :string | null) => void;
 type Props = {
   disabled :boolean;
   format :string;
@@ -29,27 +29,36 @@ const DateTimePicker = (props :Props) => {
     value
   } = props;
 
-  const [selectedDateTime, setDateTime] = useState(null);
+  const [selectedDate, setSelectedDate] = useState(null);
+  const [lastValidDate, setLastValidDate] = useState(null);
 
   useEffect(() => {
-    const datetime = DateTime.fromISO(value);
-    if (datetime.isValid) {
-      setDateTime(datetime);
+    const date = DateTime.fromISO(value);
+    if (date.isValid) {
+      setSelectedDate(date);
+      setLastValidDate(date);
+    }
+    else {
+      setSelectedDate(null);
+      setLastValidDate(null);
     }
   }, [value]);
 
-  const inputProps = useInputPropsMemo();
+  const inputProps = useInputPropsMemo(lastValidDate, setSelectedDate);
 
-  const handleDateTimeChange = useCallback<DateTimeChange>((datetime :DateTime) => {
+  const handleDateTimeChange = useCallback<DateChange>((date) => {
     if (isFunction(onChange)) {
-      if (datetime === null || !datetime.isValid) {
-        onChange('');
+      if (date === null) {
+        onChange();
+        setLastValidDate(null);
       }
-      else {
-        onChange(datetime.toISO());
+      if (date && date.isValid) {
+        const dateIso = date.toISO();
+        onChange(dateIso);
+        setLastValidDate(date);
       }
     }
-    setDateTime(datetime);
+    setSelectedDate(date);
   }, [onChange]);
 
   return (
@@ -64,7 +73,7 @@ const DateTimePicker = (props :Props) => {
             mask={mask}
             onChange={handleDateTimeChange}
             placeholder={placeholder}
-            value={selectedDateTime}
+            value={selectedDate}
             variant="inline" />
       </MuiPickersUtilsProvider>
     </ThemeProvider>

--- a/src/datetime/src/components/DateTimePicker.test.js
+++ b/src/datetime/src/components/DateTimePicker.test.js
@@ -19,7 +19,7 @@ describe('DateTimePicker', () => {
 
   describe('onChange', () => {
 
-    test('null or invalid date calls onChange with empty string', () => {
+    test('null calls onChange undefined', () => {
       const mockOnChange = jest.fn();
       const wrapper = shallow(<DateTimePicker onChange={mockOnChange} />);
 
@@ -28,11 +28,18 @@ describe('DateTimePicker', () => {
 
       innerChange(null);
       expect(mockOnChange).toHaveBeenCalledTimes(1);
-      expect(mockOnChange.mock.calls[0][0]).toEqual('');
+      expect(mockOnChange.mock.calls[0][0]).toEqual();
+    });
+
+    test('invalid date does not call onChange', () => {
+      const mockOnChange = jest.fn();
+      const wrapper = shallow(<DateTimePicker onChange={mockOnChange} />);
+
+      expect(mockOnChange).toHaveBeenCalledTimes(0);
+      const innerChange = wrapper.find(KeyboardDateTimePicker).prop('onChange');
 
       innerChange(invalidDateTime);
-      expect(mockOnChange).toHaveBeenCalledTimes(2);
-      expect(mockOnChange.mock.calls[1][0]).toEqual('');
+      expect(mockOnChange).toHaveBeenCalledTimes(0);
     });
 
     test('valid date calls onChange with ISO datetime string', () => {

--- a/src/datetime/src/components/TimePicker.js
+++ b/src/datetime/src/components/TimePicker.js
@@ -13,7 +13,7 @@ import useInputPropsMemo from './hooks/useInputPropsMemo';
 
 const ClockIcon = <FontAwesomeIcon icon={faClock} />;
 
-type TimeChange = (date :DateTime, value :string | null) => void;
+type DateChange = (date :DateTime, value :string | null) => void;
 type Props = {
   disabled :boolean;
   format :string;
@@ -34,27 +34,35 @@ const TimePicker = (props :Props) => {
   } = props;
 
   const [selectedDate, setSelectedDate] = useState(null);
+  const [lastValidDate, setLastValidDate] = useState(null);
 
   useEffect(() => {
-    const timeIso = DateTime.fromISO(value);
-    if (timeIso.isValid) {
-      setSelectedDate(timeIso);
+    const date = DateTime.fromISO(value);
+    if (date.isValid) {
+      setSelectedDate(date);
+      setLastValidDate(date);
+    }
+    else {
+      setSelectedDate(null);
+      setLastValidDate(null);
     }
   }, [value]);
 
-  const inputProps = useInputPropsMemo();
+  const inputProps = useInputPropsMemo(lastValidDate, setSelectedDate);
 
-  const handleDateChange = useCallback<TimeChange>((date) => {
+  const handleDateChange = useCallback<DateChange>((date) => {
     if (isFunction(onChange)) {
-      if (date === null || !date.isValid) {
-        onChange('');
+      if (date === null) {
+        onChange();
+        setLastValidDate(null);
       }
-      else {
-        onChange(date.toLocaleString(DateTime.TIME_24_SIMPLE));
+      if (date && date.isValid) {
+        const timeIso = date.toLocaleString(DateTime.TIME_24_SIMPLE);
+        onChange(timeIso);
+        setLastValidDate(date);
       }
     }
     setSelectedDate(date);
-
   }, [onChange]);
 
   return (

--- a/src/datetime/src/components/TimePicker.test.js
+++ b/src/datetime/src/components/TimePicker.test.js
@@ -19,7 +19,7 @@ describe('TimePicker', () => {
 
   describe('onChange', () => {
 
-    test('null or invalid date calls onChange with empty string', () => {
+    test('null calls onChange with undefined', () => {
       const mockOnChange = jest.fn();
       const wrapper = shallow(<TimePicker onChange={mockOnChange} />);
 
@@ -28,11 +28,18 @@ describe('TimePicker', () => {
 
       innerChange(null);
       expect(mockOnChange).toHaveBeenCalledTimes(1);
-      expect(mockOnChange.mock.calls[0][0]).toEqual('');
+      expect(mockOnChange.mock.calls[0][0]).toEqual();
+    });
+
+    test('invalid date does not call onChange', () => {
+      const mockOnChange = jest.fn();
+      const wrapper = shallow(<TimePicker onChange={mockOnChange} />);
+
+      expect(mockOnChange).toHaveBeenCalledTimes(0);
+      const innerChange = wrapper.find(KeyboardTimePicker).prop('onChange');
 
       innerChange(invalidTime);
-      expect(mockOnChange).toHaveBeenCalledTimes(2);
-      expect(mockOnChange.mock.calls[1][0]).toEqual('');
+      expect(mockOnChange).toHaveBeenCalledTimes(0);
     });
 
     test('valid date calls onChange with ISO time string', () => {

--- a/src/datetime/src/components/__snapshots__/DatePicker.test.js.snap
+++ b/src/datetime/src/components/__snapshots__/DatePicker.test.js.snap
@@ -369,6 +369,7 @@ exports[`DatePicker render matches snapshot 1`] = `
       <PickerWithState
         InputProps={
           Object {
+            "onBlur": [Function],
             "onKeyDown": [Function],
           }
         }
@@ -407,6 +408,7 @@ exports[`DatePicker render matches snapshot 1`] = `
           InputComponent={[Function]}
           InputProps={
             Object {
+              "onBlur": [Function],
               "onKeyDown": [Function],
             }
           }
@@ -435,6 +437,7 @@ exports[`DatePicker render matches snapshot 1`] = `
             InputComponent={[Function]}
             InputProps={
               Object {
+                "onBlur": [Function],
                 "onKeyDown": [Function],
               }
             }
@@ -452,6 +455,7 @@ exports[`DatePicker render matches snapshot 1`] = `
             <KeyboardDateInput
               InputProps={
                 Object {
+                  "onBlur": [Function],
                   "onKeyDown": [Function],
                 }
               }
@@ -497,6 +501,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                           <KeyboardIcon />
                         </ForwardRef(WithStyles)>
                       </ForwardRef(WithStyles)>,
+                      "onBlur": [Function],
                       "onKeyDown": [Function],
                     }
                   }
@@ -532,6 +537,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                             <KeyboardIcon />
                           </ForwardRef(WithStyles)>
                         </ForwardRef(WithStyles)>,
+                        "onBlur": [Function],
                         "onKeyDown": [Function],
                       }
                     }
@@ -611,6 +617,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                               }
                             }
                             labelWidth={0}
+                            onBlur={[Function]}
                             onChange={[Function]}
                             onKeyDown={[Function]}
                             placeholder="MM/DD/YYYY"
@@ -661,6 +668,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                               }
                               labelWidth={0}
                               notched={false}
+                              onBlur={[Function]}
                               onChange={[Function]}
                               onKeyDown={[Function]}
                               placeholder="MM/DD/YYYY"
@@ -712,6 +720,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                                   }
                                 }
                                 multiline={false}
+                                onBlur={[Function]}
                                 onChange={[Function]}
                                 onKeyDown={[Function]}
                                 placeholder="MM/DD/YYYY"
@@ -768,6 +777,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                                     }
                                   }
                                   multiline={false}
+                                  onBlur={[Function]}
                                   onChange={[Function]}
                                   onKeyDown={[Function]}
                                   placeholder="MM/DD/YYYY"

--- a/src/datetime/src/components/__snapshots__/DateTimePicker.test.js.snap
+++ b/src/datetime/src/components/__snapshots__/DateTimePicker.test.js.snap
@@ -369,6 +369,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
       <PickerWithState
         InputProps={
           Object {
+            "onBlur": [Function],
             "onKeyDown": [Function],
           }
         }
@@ -413,6 +414,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
           InputComponent={[Function]}
           InputProps={
             Object {
+              "onBlur": [Function],
               "onKeyDown": [Function],
             }
           }
@@ -444,6 +446,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
             InputComponent={[Function]}
             InputProps={
               Object {
+                "onBlur": [Function],
                 "onKeyDown": [Function],
               }
             }
@@ -464,6 +467,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
             <KeyboardDateInput
               InputProps={
                 Object {
+                  "onBlur": [Function],
                   "onKeyDown": [Function],
                 }
               }
@@ -510,6 +514,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                           <KeyboardIcon />
                         </ForwardRef(WithStyles)>
                       </ForwardRef(WithStyles)>,
+                      "onBlur": [Function],
                       "onKeyDown": [Function],
                     }
                   }
@@ -545,6 +550,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                             <KeyboardIcon />
                           </ForwardRef(WithStyles)>
                         </ForwardRef(WithStyles)>,
+                        "onBlur": [Function],
                         "onKeyDown": [Function],
                       }
                     }
@@ -624,6 +630,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                               }
                             }
                             labelWidth={0}
+                            onBlur={[Function]}
                             onChange={[Function]}
                             onKeyDown={[Function]}
                             placeholder="MM/DD/YYYY  HH:MM AM"
@@ -674,6 +681,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                               }
                               labelWidth={0}
                               notched={false}
+                              onBlur={[Function]}
                               onChange={[Function]}
                               onKeyDown={[Function]}
                               placeholder="MM/DD/YYYY  HH:MM AM"
@@ -725,6 +733,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                                   }
                                 }
                                 multiline={false}
+                                onBlur={[Function]}
                                 onChange={[Function]}
                                 onKeyDown={[Function]}
                                 placeholder="MM/DD/YYYY  HH:MM AM"
@@ -781,6 +790,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                                     }
                                   }
                                   multiline={false}
+                                  onBlur={[Function]}
                                   onChange={[Function]}
                                   onKeyDown={[Function]}
                                   placeholder="MM/DD/YYYY  HH:MM AM"

--- a/src/datetime/src/components/__snapshots__/TimePicker.test.js.snap
+++ b/src/datetime/src/components/__snapshots__/TimePicker.test.js.snap
@@ -369,6 +369,7 @@ exports[`TimePicker render matches snapshot 1`] = `
       <PickerWithState
         InputProps={
           Object {
+            "onBlur": [Function],
             "onKeyDown": [Function],
           }
         }
@@ -436,6 +437,7 @@ exports[`TimePicker render matches snapshot 1`] = `
           InputComponent={[Function]}
           InputProps={
             Object {
+              "onBlur": [Function],
               "onKeyDown": [Function],
             }
           }
@@ -498,6 +500,7 @@ exports[`TimePicker render matches snapshot 1`] = `
             InputComponent={[Function]}
             InputProps={
               Object {
+                "onBlur": [Function],
                 "onKeyDown": [Function],
               }
             }
@@ -549,6 +552,7 @@ exports[`TimePicker render matches snapshot 1`] = `
             <KeyboardDateInput
               InputProps={
                 Object {
+                  "onBlur": [Function],
                   "onKeyDown": [Function],
                 }
               }
@@ -657,6 +661,7 @@ exports[`TimePicker render matches snapshot 1`] = `
                           />
                         </ForwardRef(WithStyles)>
                       </ForwardRef(WithStyles)>,
+                      "onBlur": [Function],
                       "onKeyDown": [Function],
                     }
                   }
@@ -722,6 +727,7 @@ exports[`TimePicker render matches snapshot 1`] = `
                             />
                           </ForwardRef(WithStyles)>
                         </ForwardRef(WithStyles)>,
+                        "onBlur": [Function],
                         "onKeyDown": [Function],
                       }
                     }
@@ -831,6 +837,7 @@ exports[`TimePicker render matches snapshot 1`] = `
                               }
                             }
                             labelWidth={0}
+                            onBlur={[Function]}
                             onChange={[Function]}
                             onKeyDown={[Function]}
                             placeholder="HH:MM AM"
@@ -911,6 +918,7 @@ exports[`TimePicker render matches snapshot 1`] = `
                               }
                               labelWidth={0}
                               notched={false}
+                              onBlur={[Function]}
                               onChange={[Function]}
                               onKeyDown={[Function]}
                               placeholder="HH:MM AM"
@@ -992,6 +1000,7 @@ exports[`TimePicker render matches snapshot 1`] = `
                                   }
                                 }
                                 multiline={false}
+                                onBlur={[Function]}
                                 onChange={[Function]}
                                 onKeyDown={[Function]}
                                 placeholder="HH:MM AM"
@@ -1078,6 +1087,7 @@ exports[`TimePicker render matches snapshot 1`] = `
                                     }
                                   }
                                   multiline={false}
+                                  onBlur={[Function]}
                                   onChange={[Function]}
                                   onKeyDown={[Function]}
                                   placeholder="HH:MM AM"

--- a/src/datetime/src/components/hooks/useInputPropsMemo.js
+++ b/src/datetime/src/components/hooks/useInputPropsMemo.js
@@ -1,18 +1,22 @@
 // @flow
 import { useMemo } from 'react';
+import type { DateTime } from 'luxon';
 import { ENTER_KEY_CODE } from '../../../../utils/keycodes';
 
 // Provide reference equality InputProps with onKeyDown event
 // For Mui Pickers only
 
-const useInputPropsMemo = () => {
+const useInputPropsMemo = (lastValidDate :?DateTime, setSelectedDate :(date :?DateTime) => void) => {
   const inputProps = useMemo(() => ({
     onKeyDown: (e :SyntheticKeyboardEvent<HTMLInputElement>) => {
       if (e.key === ENTER_KEY_CODE) {
         e.preventDefault();
       }
+    },
+    onBlur: () => {
+      setSelectedDate(lastValidDate);
     }
-  }), []);
+  }), [lastValidDate, setSelectedDate]);
 
   return inputProps;
 };

--- a/src/datetime/src/components/hooks/useInputPropsMemo.test.js
+++ b/src/datetime/src/components/hooks/useInputPropsMemo.test.js
@@ -1,0 +1,84 @@
+// @flow
+import React from 'react';
+import { mount } from 'enzyme';
+import { DateTime } from 'luxon';
+
+import useInputPropsMemo from './useInputPropsMemo';
+
+type Props = {
+  lastValidDate :any;
+  setSelectedDate :(date :any) => void;
+}
+
+const MockComponent = (props :Props) => {
+  const { lastValidDate, setSelectedDate } = props;
+  const { onKeyDown, onBlur } = useInputPropsMemo(lastValidDate, setSelectedDate);
+
+  return (
+    <input onKeyDown={onKeyDown} onBlur={onBlur} />
+  );
+};
+
+describe('useInputPropsMemo', () => {
+  describe('onKeyDown', () => {
+    test('should have onKeyDown function', () => {
+      const lastValidDate = DateTime.local();
+      const mockSetSelectedDate = jest.fn();
+      const wrapper = mount(
+        <MockComponent lastValidDate={lastValidDate} setSelectedDate={mockSetSelectedDate} />
+      );
+
+      expect(typeof wrapper.find('input').prop('onKeyDown')).toEqual('function');
+    });
+
+    test('input should preventDefault only for Enter keyPress', () => {
+      const lastValidDate = DateTime.local();
+      const mockSetSelectedDate = jest.fn();
+      const preventDefault = jest.fn();
+      const wrapper = mount(
+        <MockComponent lastValidDate={lastValidDate} setSelectedDate={mockSetSelectedDate} />
+      );
+      const input = wrapper.find('input');
+
+      expect(preventDefault).toHaveBeenCalledTimes(0);
+
+      input.simulate('keyDown', {
+        preventDefault,
+        key: 'Enter'
+      });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+
+      input.simulate('keyDown', {
+        preventDefault,
+        key: 'Escape'
+      });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onBlur', () => {
+    test('should have onBlur function', () => {
+      const lastValidDate = DateTime.local();
+      const mockSetSelectedDate = jest.fn();
+      const wrapper = mount(
+        <MockComponent lastValidDate={lastValidDate} setSelectedDate={mockSetSelectedDate} />
+      );
+
+      expect(typeof wrapper.find('input').prop('onBlur')).toEqual('function');
+    });
+
+    test('onBlur should invoke setSelectedDate with lastValidDate as arg', () => {
+      const lastValidDate = DateTime.local();
+      const mockSetSelectedDate = jest.fn();
+      const wrapper = mount(
+        <MockComponent lastValidDate={lastValidDate} setSelectedDate={mockSetSelectedDate} />
+      );
+
+      const input = wrapper.find('input');
+      input.simulate('blur');
+      expect(mockSetSelectedDate.mock.calls[0][0]).toEqual(lastValidDate);
+    });
+  });
+});

--- a/src/datetime/stories/index.stories.js
+++ b/src/datetime/stories/index.stories.js
@@ -39,6 +39,7 @@ storiesOf('Date and Time', module)
             <Label subtle>Controlled</Label>
             <DatePicker
                 onChange={(value) => {
+                  console.log(value);
                   dateMuiChange(value);
                   setSelectedDate(value);
                 }}

--- a/src/datetime/stories/index.stories.js
+++ b/src/datetime/stories/index.stories.js
@@ -39,7 +39,6 @@ storiesOf('Date and Time', module)
             <Label subtle>Controlled</Label>
             <DatePicker
                 onChange={(value) => {
-                  console.log(value);
                   dateMuiChange(value);
                   setSelectedDate(value);
                 }}


### PR DESCRIPTION
# Changes
- Invalid dates will revert to the last valid DateTime or null onBlur
- **BREAKING** Empty/cleared picker inputs return `undefined` instead of an empty string

![image](https://i.gyazo.com/d607231ec23141b0189f9664bbf5538c.gif)
