### PR TITLE
Task/modal spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "eslint-plugin-react": "~7.15.0",
     "eslint-plugin-react-hooks": "~2.2.0",
     "file-loader": "~4.2.0",
-    "flow-bin": "~0.111.0",
+    "flow-bin": "~0.112.0",
     "jest": "~24.8.0",
     "jest-styled-components": "~6.3.0",
     "npm-run-all": "~4.1.0",

--- a/src/button/src/components/CopyButton.js
+++ b/src/button/src/components/CopyButton.js
@@ -8,7 +8,7 @@ import { faCopy } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import IconButton from './IconButton';
-import type { Props } from './Button';
+import type { Props } from './IconButton';
 
 const icon = (
   <FontAwesomeIcon icon={faCopy} />

--- a/src/button/src/components/EditButton.js
+++ b/src/button/src/components/EditButton.js
@@ -8,7 +8,7 @@ import { faPen } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import IconButton from './IconButton';
-import type { Props } from './Button';
+import type { Props } from './IconButton';
 
 const icon = (
   <FontAwesomeIcon icon={faPen} />

--- a/src/button/src/components/IconButton.js
+++ b/src/button/src/components/IconButton.js
@@ -14,8 +14,7 @@ const IconMarginRight = styled.span`
   margin: 0 8px 0 0;
 `;
 
-type Props = {
-  ...ButtonProps;
+type Props = ButtonProps & {
   icon ?:Element<any>;
 };
 

--- a/src/button/src/components/MinusButton.js
+++ b/src/button/src/components/MinusButton.js
@@ -8,7 +8,7 @@ import { faMinus } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import IconButton from './IconButton';
-import type { Props } from './Button';
+import type { Props } from './IconButton';
 
 const icon = (
   <FontAwesomeIcon icon={faMinus} />

--- a/src/button/src/components/PlusButton.js
+++ b/src/button/src/components/PlusButton.js
@@ -8,7 +8,7 @@ import { faPlus } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import IconButton from './IconButton';
-import type { Props } from './Button';
+import type { Props } from './IconButton';
 
 const icon = (
   <FontAwesomeIcon icon={faPlus} />

--- a/src/button/src/components/SearchButton.js
+++ b/src/button/src/components/SearchButton.js
@@ -8,7 +8,7 @@ import { faSearch } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import IconButton from './IconButton';
-import type { Props } from './Button';
+import type { Props } from './IconButton';
 
 const icon = (
   <FontAwesomeIcon icon={faSearch} />

--- a/src/choices/src/components/Checkbox.js
+++ b/src/choices/src/components/Checkbox.js
@@ -37,6 +37,7 @@ const Checkbox = ({
             id={id}
             readOnly={readOnly}
             disabled={disabled || readOnly}
+            // $FlowFixMe
             {...rest} />
         <CheckboxIndicator />
       </ChoiceInnerWrapper>

--- a/src/choices/src/components/Radio.js
+++ b/src/choices/src/components/Radio.js
@@ -36,6 +36,7 @@ const Radio = ({
             id={id}
             readOnly={readOnly}
             disabled={disabled || readOnly}
+            // $FlowFixMe
             {...rest} />
         <RadioIndicator />
       </ChoiceInnerWrapper>

--- a/src/modal/src/components/Modal.test.js
+++ b/src/modal/src/components/Modal.test.js
@@ -431,7 +431,7 @@ describe('modal', () => {
           expect(modalOuterContainer).toHaveStyleRule('min-height', '100%');
 
           const modalInnerContainer = modal.find(ModalInnerContainer);
-          expect(modalInnerContainer).toHaveStyleRule('max-height', 'calc(100vh - 240px)');
+          expect(modalInnerContainer).toHaveStyleRule('max-height', 'calc(100vh - 120px)');
           expect(modalInnerContainer).toHaveStyleRule('margin', '0');
         });
 
@@ -466,7 +466,7 @@ describe('modal', () => {
 
           const modalInnerContainer = modal.find(ModalInnerContainer);
           expect(modalInnerContainer).not.toHaveStyleRule('max-height');
-          expect(modalInnerContainer).toHaveStyleRule('margin', '120px 0');
+          expect(modalInnerContainer).toHaveStyleRule('margin', '60px 0');
         });
 
         test('should pass "isScrollable=true" to the overlay component', () => {

--- a/src/modal/src/components/__snapshots__/ActionModal.test.js.snap
+++ b/src/modal/src/components/__snapshots__/ActionModal.test.js.snap
@@ -105,12 +105,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -293,6 +293,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   width: 32px;
 }
 
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
+}
+
 <ActionModal
   isVisible={true}
   onClickPrimary={[Function]}
@@ -456,12 +462,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -642,6 +648,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -877,8 +889,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],
@@ -1484,12 +1506,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -1670,6 +1692,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <ActionModal
@@ -1859,12 +1887,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -2045,6 +2073,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -2280,8 +2314,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],
@@ -2887,12 +2931,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -3162,6 +3206,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   width: 32px;
 }
 
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
+}
+
 <ActionModal
   isVisible={true}
   onClickPrimary={[Function]}
@@ -3324,12 +3374,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -3597,6 +3647,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -3891,8 +3947,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],
@@ -4864,12 +4930,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -5139,6 +5205,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   width: 32px;
 }
 
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
+}
+
 <ActionModal
   isVisible={true}
   onClickPrimary={[Function]}
@@ -5325,12 +5397,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -5598,6 +5670,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -5892,8 +5970,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],
@@ -6865,12 +6953,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -7109,6 +7197,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   width: 32px;
 }
 
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
+}
+
 <ActionModal
   isVisible={true}
   onClickPrimary={[Function]}
@@ -7260,12 +7354,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -7502,6 +7596,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -7752,8 +7852,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],
@@ -8551,12 +8661,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -8795,6 +8905,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   width: 32px;
 }
 
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
+}
+
 <ActionModal
   isVisible={true}
   onClickPrimary={[Function]}
@@ -8970,12 +9086,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -9212,6 +9328,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -9462,8 +9584,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],
@@ -10261,12 +10393,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -10449,6 +10581,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   width: 32px;
 }
 
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
+}
+
 <ActionModal
   isVisible={true}
   onClickPrimary={[Function]}
@@ -10612,12 +10750,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -10798,6 +10936,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -11033,8 +11177,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],
@@ -11640,12 +11794,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -11826,6 +11980,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <ActionModal
@@ -12015,12 +12175,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -12201,6 +12361,12 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -12436,8 +12602,18 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
                                                         ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                         "#555e6f",
                                                         ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                        "240",
+                                                        "120",
                                                         "px);min-height:200px;min-width:300px;position:relative;",
+                                                        "@media (max-width:",
+                                                        "36",
+                                                        "em){",
+                                                        "
+    max-width: calc(100vw - ",
+                                                        "60",
+                                                        "px);
+  ",
+                                                        "}",
+                                                        " ",
                                                         [Function],
                                                         " ",
                                                         [Function],

--- a/src/modal/src/components/__snapshots__/Modal.test.js.snap
+++ b/src/modal/src/components/__snapshots__/Modal.test.js.snap
@@ -142,12 +142,12 @@ exports[`modal snapshots should match snapshot when isVisible="true" 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -386,6 +386,12 @@ exports[`modal snapshots should match snapshot when isVisible="true" 1`] = `
   width: 32px;
 }
 
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
+}
+
 <Modal
   isVisible={true}
   onClickPrimary={[Function]}
@@ -524,12 +530,12 @@ exports[`modal snapshots should match snapshot when isVisible="true" 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  max-width: calc(100vw - 240px);
+  max-width: calc(100vw - 120px);
   min-height: 200px;
   min-width: 300px;
   position: relative;
   margin: 0;
-  max-height: calc(100vh - 240px);
+  max-height: calc(100vh - 120px);
 }
 
 .c7 {
@@ -766,6 +772,12 @@ exports[`modal snapshots should match snapshot when isVisible="true" 1`] = `
   padding: 0;
   text-align: center;
   width: 32px;
+}
+
+@media (max-width:36em) {
+  .c3 {
+    max-width: calc(100vw - 60px);
+  }
 }
 
 <div
@@ -1016,8 +1028,18 @@ exports[`modal snapshots should match snapshot when isVisible="true" 1`] = `
                                                       ";border-radius:3px;box-shadow:0 2px 8px -2px ",
                                                       "#555e6f",
                                                       ";display:flex;flex:0 0 auto;flex-direction:column;max-width:calc(100vw - ",
-                                                      "240",
+                                                      "120",
                                                       "px);min-height:200px;min-width:300px;position:relative;",
+                                                      "@media (max-width:",
+                                                      "36",
+                                                      "em){",
+                                                      "
+    max-width: calc(100vw - ",
+                                                      "60",
+                                                      "px);
+  ",
+                                                      "}",
+                                                      " ",
                                                       [Function],
                                                       " ",
                                                       [Function],

--- a/src/modal/src/components/styled/StyledModalComponents.js
+++ b/src/modal/src/components/styled/StyledModalComponents.js
@@ -5,9 +5,10 @@
 import styled, { css } from 'styled-components';
 
 import { NEUTRALS, WHITE } from '../../../../colors';
+import { media } from '../../../../utils/StyleUtils';
 
 const DEFAULT_PADDING :number = 30;
-const VIEWPORT_PADDING :number = 120;
+const VIEWPORT_PADDING :number = 60;
 
 const getOuterContainerHeight = ({ viewportScrolling }) => {
 
@@ -99,6 +100,10 @@ export const ModalInnerContainer = styled.div`
   min-height: 200px; /* = 2 * 100px, where 100px is the "min-height" of ModalSection */
   min-width: 300px;
   position: relative;
+
+  ${media.phone`
+    max-width: calc(100vw - ${VIEWPORT_PADDING}px);
+  `}
   ${getInnerContainerMargin}
   ${getInnerContainerMaxHeight}
 `;

--- a/src/utils/StyleUtils.js
+++ b/src/utils/StyleUtils.js
@@ -48,15 +48,18 @@ const getHoverStyles = (props :{ onClick :() => any }) => {
   return null;
 };
 
+// TODO: Refine and justify media query sizes
+// Loosely based on 4:3 ratio and using em units
 const sizes = {
-  desktop: 992,
-  tablet: 768,
-  phone: 576,
+  desktop: 1024, // 60em
+  tablet: 768, // 48em
+  phone: 576, // 36em
 };
 
-// https://www.styled-components.com/docs/advanced#media-templates
-// font-size: 16
+// https://github.com/styled-components/styled-components/pull/183/files
 const media = Object.keys(sizes).reduce((acc, label) => {
+  // em-based media queries adapt better when browser is zoomed
+  // browser defaults to 16px = 1em
   acc[label] = (...styles :any) => css`
     @media (max-width: ${sizes[label] / 16}em) {
       ${css(...styles)}

--- a/src/utils/StyleUtils.js
+++ b/src/utils/StyleUtils.js
@@ -48,8 +48,28 @@ const getHoverStyles = (props :{ onClick :() => any }) => {
   return null;
 };
 
+const sizes = {
+  desktop: 992,
+  tablet: 768,
+  phone: 576,
+};
+
+// https://www.styled-components.com/docs/advanced#media-templates
+// font-size: 16
+const media = Object.keys(sizes).reduce((acc, label) => {
+  acc[label] = (...args) => css`
+    @media (max-width: ${sizes[label] / 16}em) {
+      ${css(...args)}
+    }
+  `;
+
+  return acc;
+}, {});
+
+
 export {
   getHoverStyles,
   getStickyPosition,
   getStyleVariation,
+  media,
 };

--- a/src/utils/StyleUtils.js
+++ b/src/utils/StyleUtils.js
@@ -57,9 +57,9 @@ const sizes = {
 // https://www.styled-components.com/docs/advanced#media-templates
 // font-size: 16
 const media = Object.keys(sizes).reduce((acc, label) => {
-  acc[label] = (...args) => css`
+  acc[label] = (...styles :any) => css`
     @media (max-width: ${sizes[label] / 16}em) {
-      ${css(...args)}
+      ${css(...styles)}
     }
   `;
 


### PR DESCRIPTION
- add `media` to StyleUtils
- Reduce modal viewport margin by 50%
  - Bake in media query to adjust for small screens
  - Before: 
![image](https://user-images.githubusercontent.com/27182199/68742365-dab08b80-05a4-11ea-90c5-b7e0830fa774.png)
  - After: 
![image](https://user-images.githubusercontent.com/27182199/68742393-ea2fd480-05a4-11ea-9879-104461e4abe5.png)

