### PR TITLE
Exact table data

### DIFF
--- a/src/table/src/components/PaginationToolbar.js
+++ b/src/table/src/components/PaginationToolbar.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import isFunction from 'lodash/isFunction';
 import { faChevronLeft, faChevronRight } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -11,6 +12,7 @@ import Label from '../../../label';
 
 type Props = {
   count :number;
+  onPageChange ?:(payload :any) => void;
   page :number;
   rowsPerPage :number;
   rowsPerPageOptions ? :number[];
@@ -21,6 +23,7 @@ type Props = {
 const PaginationToolbar = (props :Props) => {
   const {
     count,
+    onPageChange,
     page,
     rowsPerPage,
     rowsPerPageOptions,
@@ -35,6 +38,30 @@ const PaginationToolbar = (props :Props) => {
   const minRowNumber = Math.min(rowsPerPage * page + 1, count);
   const rowRange = `${minRowNumber} - ${maxRowNumber} of ${count}`;
 
+  const getPageChanger = (increment :number) => () => {
+    const newPage = page + increment;
+    setPage(newPage);
+    if (isFunction(onPageChange)) {
+      onPageChange({
+        page: newPage,
+        start: Math.min(rowsPerPage * newPage, count),
+        rowsPerPage,
+      });
+    }
+  };
+
+  const handleRowsPerPage = (rows) => {
+    setPage(0);
+    setRowsPerPage(rows);
+    if (isFunction(onPageChange)) {
+      onPageChange({
+        page: 0,
+        start: 0,
+        rowsPerPage: rows
+      });
+    }
+  };
+
   return (
     <PaginationWrapper>
       <Label subtle>Rows per page</Label>
@@ -44,10 +71,7 @@ const PaginationToolbar = (props :Props) => {
             <Select
                 borderless
                 defaultValue={options[0]}
-                onChange={(rows) => {
-                  setPage(0);
-                  setRowsPerPage(rows);
-                }}
+                onChange={handleRowsPerPage}
                 options={options}
                 value={rowsPerPage}
                 useRawValues />
@@ -59,21 +83,22 @@ const PaginationToolbar = (props :Props) => {
           mode="subtle"
           icon={<FontAwesomeIcon icon={faChevronLeft} fixedWidth />}
           disabled={page <= 0}
-          onClick={() => setPage(page - 1)} />
+          onClick={getPageChanger(-1)} />
       <IconButton
           mode="subtle"
           icon={<FontAwesomeIcon icon={faChevronRight} fixedWidth />}
           disabled={page >= lastPage}
-          onClick={() => setPage(page + 1)} />
+          onClick={getPageChanger(1)} />
     </PaginationWrapper>
   );
 };
 
 PaginationToolbar.defaultProps = {
   count: 0,
+  onPageChange: undefined,
   page: 0,
   rowsPerPage: 5,
-  rowsPerPageOptions: []
+  rowsPerPageOptions: [],
 };
 
 // $FlowFixMe

--- a/src/table/src/components/PaginationToolbar.js
+++ b/src/table/src/components/PaginationToolbar.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import isFunction from 'lodash/isFunction';
 import { faChevronLeft, faChevronRight } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -42,13 +41,15 @@ const PaginationToolbar = (props :Props) => {
     onPageChange({
       page: newPage,
       rowsPerPage,
+      start: Math.min(rowsPerPage * newPage, count)
     }, event);
   };
 
   const handleRowsPerPage = (rows, event) => {
     onPageChange({
       page: 0,
-      rowsPerPage: rows
+      rowsPerPage: rows,
+      start: 0
     }, event);
   };
 

--- a/src/table/src/components/PaginationToolbar.js
+++ b/src/table/src/components/PaginationToolbar.js
@@ -12,7 +12,11 @@ import Label from '../../../label';
 
 type Props = {
   count :number;
-  onPageChange ?:(payload :any) => void;
+  onPageChange ?:({
+    page :number,
+    start :number,
+    rowsPerPage :number
+  }) => void;
   page :number;
   rowsPerPage :number;
   rowsPerPageOptions ? :number[];

--- a/src/table/src/components/PaginationToolbar.js
+++ b/src/table/src/components/PaginationToolbar.js
@@ -12,16 +12,13 @@ import Label from '../../../label';
 
 type Props = {
   count :number;
-  onPageChange ?:({
+  onPageChange :({
     page :number,
-    start :number,
     rowsPerPage :number
-  }) => void;
+  }, event :SyntheticEvent<HTMLButtonElement>) => void;
   page :number;
   rowsPerPage :number;
   rowsPerPageOptions ? :number[];
-  setPage :(number :number) => void;
-  setRowsPerPage :(number :number) => void;
 };
 
 const PaginationToolbar = (props :Props) => {
@@ -31,8 +28,6 @@ const PaginationToolbar = (props :Props) => {
     page,
     rowsPerPage,
     rowsPerPageOptions,
-    setPage,
-    setRowsPerPage,
   } = props;
 
   const options = getRowsPerPageOptions(rowsPerPageOptions, count);
@@ -42,28 +37,19 @@ const PaginationToolbar = (props :Props) => {
   const minRowNumber = Math.min(rowsPerPage * page + 1, count);
   const rowRange = `${minRowNumber} - ${maxRowNumber} of ${count}`;
 
-  const getPageChanger = (increment :number) => () => {
+  const getPageChanger = (increment :number) => (event :SyntheticEvent<HTMLButtonElement>) => {
     const newPage = page + increment;
-    setPage(newPage);
-    if (isFunction(onPageChange)) {
-      onPageChange({
-        page: newPage,
-        start: Math.min(rowsPerPage * newPage, count),
-        rowsPerPage,
-      });
-    }
+    onPageChange({
+      page: newPage,
+      rowsPerPage,
+    }, event);
   };
 
-  const handleRowsPerPage = (rows) => {
-    setPage(0);
-    setRowsPerPage(rows);
-    if (isFunction(onPageChange)) {
-      onPageChange({
-        page: 0,
-        start: 0,
-        rowsPerPage: rows
-      });
-    }
+  const handleRowsPerPage = (rows, event) => {
+    onPageChange({
+      page: 0,
+      rowsPerPage: rows
+    }, event);
   };
 
   return (

--- a/src/table/src/components/PaginationToolbar.test.js
+++ b/src/table/src/components/PaginationToolbar.test.js
@@ -20,41 +20,60 @@ describe('PaginationToolbar', () => {
   });
 
   describe('props', () => {
-    describe('setPage and setRowsPerPage', () => {
-      let mockSetPage;
-      let mockSetRowsPerPage;
-      let wrapper;
-      let buttons;
-      beforeEach(() => {
-        mockSetPage = jest.fn();
-        mockSetRowsPerPage = jest.fn();
-        wrapper = mount(
-          <PaginationToolbar
-              page={0}
-              setPage={mockSetPage}
-              setRowsPerPage={mockSetRowsPerPage}
-              rowsPerPageOptions={[5, 10]} />
-        );
-        buttons = wrapper.find(IconButton);
-      });
-      test('should invoke setPage with page - 1 when back button is clicked', () => {
+    let buttons;
+    let mockOnPageChange;
+    let mockSetPage;
+    let mockSetRowsPerPage;
+    let wrapper;
+    beforeEach(() => {
+      mockSetPage = jest.fn();
+      mockSetRowsPerPage = jest.fn();
+      mockOnPageChange = jest.fn();
+      wrapper = mount(
+        <PaginationToolbar
+            count={10}
+            onPageChange={mockOnPageChange}
+            page={1}
+            rowsPerPageOptions={[5, 10]}
+            setPage={mockSetPage}
+            setRowsPerPage={mockSetRowsPerPage} />
+      );
+      buttons = wrapper.find(IconButton);
+    });
+
+    describe('change page', () => {
+      test('should invoke setPage and onPageChange when back button is clicked', () => {
         const prevButton = buttons.get(0);
 
         expect(mockSetPage).toHaveBeenCalledTimes(0);
         prevButton.props.onClick();
         expect(mockSetPage).toHaveBeenCalledTimes(1);
-        expect(mockSetPage.mock.calls[0][0]).toEqual(-1);
+        expect(mockSetPage.mock.calls[0][0]).toEqual(0);
+
+        expect(mockOnPageChange.mock.calls[0][0]).toEqual({
+          page: 0,
+          start: 0,
+          rowsPerPage: 5
+        });
       });
 
-      test('should invoke setPage with page + 1 when back button is clicked', () => {
+      test('should invoke setPage and onPageChange when next button is clicked', () => {
         const nextButton = buttons.get(1);
 
         expect(mockSetPage).toHaveBeenCalledTimes(0);
         nextButton.props.onClick();
         expect(mockSetPage).toHaveBeenCalledTimes(1);
-        expect(mockSetPage.mock.calls[0][0]).toEqual(1);
-      });
+        expect(mockSetPage.mock.calls[0][0]).toEqual(2);
 
+        expect(mockOnPageChange.mock.calls[0][0]).toEqual({
+          page: 2,
+          start: 10,
+          rowsPerPage: 5
+        });
+      });
+    });
+
+    describe('change rowsPerPage', () => {
       test('should setPage to 0 for Select onChange', () => {
         const select = wrapper.find(Select).get(0);
 
@@ -65,6 +84,15 @@ describe('PaginationToolbar', () => {
       });
 
       test('should setRowsPerPage when Select onChange', () => {
+        const select = wrapper.find(Select).get(0);
+
+        expect(mockSetRowsPerPage).toHaveBeenCalledTimes(0);
+        select.props.onChange(20);
+        expect(mockSetRowsPerPage).toHaveBeenCalledTimes(1);
+        expect(mockSetRowsPerPage.mock.calls[0][0]).toEqual(20);
+      });
+
+      test('should invoke onPageChange when Select onChange', () => {
         const select = wrapper.find(Select).get(0);
 
         expect(mockSetRowsPerPage).toHaveBeenCalledTimes(0);

--- a/src/table/src/components/PaginationToolbar.test.js
+++ b/src/table/src/components/PaginationToolbar.test.js
@@ -22,21 +22,15 @@ describe('PaginationToolbar', () => {
   describe('props', () => {
     let buttons;
     let mockOnPageChange;
-    let mockSetPage;
-    let mockSetRowsPerPage;
     let wrapper;
     beforeEach(() => {
-      mockSetPage = jest.fn();
-      mockSetRowsPerPage = jest.fn();
       mockOnPageChange = jest.fn();
       wrapper = mount(
         <PaginationToolbar
             count={10}
             onPageChange={mockOnPageChange}
             page={1}
-            rowsPerPageOptions={[5, 10]}
-            setPage={mockSetPage}
-            setRowsPerPage={mockSetRowsPerPage} />
+            rowsPerPageOptions={[5, 10]} />
       );
       buttons = wrapper.find(IconButton);
     });
@@ -45,10 +39,7 @@ describe('PaginationToolbar', () => {
       test('should invoke setPage and onPageChange when back button is clicked', () => {
         const prevButton = buttons.get(0);
 
-        expect(mockSetPage).toHaveBeenCalledTimes(0);
         prevButton.props.onClick();
-        expect(mockSetPage).toHaveBeenCalledTimes(1);
-        expect(mockSetPage.mock.calls[0][0]).toEqual(0);
 
         expect(mockOnPageChange.mock.calls[0][0]).toEqual({
           page: 0,
@@ -60,10 +51,7 @@ describe('PaginationToolbar', () => {
       test('should invoke setPage and onPageChange when next button is clicked', () => {
         const nextButton = buttons.get(1);
 
-        expect(mockSetPage).toHaveBeenCalledTimes(0);
         nextButton.props.onClick();
-        expect(mockSetPage).toHaveBeenCalledTimes(1);
-        expect(mockSetPage.mock.calls[0][0]).toEqual(2);
 
         expect(mockOnPageChange.mock.calls[0][0]).toEqual({
           page: 2,
@@ -74,31 +62,17 @@ describe('PaginationToolbar', () => {
     });
 
     describe('change rowsPerPage', () => {
-      test('should setPage to 0 for Select onChange', () => {
-        const select = wrapper.find(Select).get(0);
-
-        expect(mockSetPage).toHaveBeenCalledTimes(0);
-        select.props.onChange();
-        expect(mockSetPage).toHaveBeenCalledTimes(1);
-        expect(mockSetPage.mock.calls[0][0]).toEqual(0);
-      });
-
-      test('should setRowsPerPage when Select onChange', () => {
-        const select = wrapper.find(Select).get(0);
-
-        expect(mockSetRowsPerPage).toHaveBeenCalledTimes(0);
-        select.props.onChange(20);
-        expect(mockSetRowsPerPage).toHaveBeenCalledTimes(1);
-        expect(mockSetRowsPerPage.mock.calls[0][0]).toEqual(20);
-      });
 
       test('should invoke onPageChange when Select onChange', () => {
         const select = wrapper.find(Select).get(0);
 
-        expect(mockSetRowsPerPage).toHaveBeenCalledTimes(0);
         select.props.onChange(20);
-        expect(mockSetRowsPerPage).toHaveBeenCalledTimes(1);
-        expect(mockSetRowsPerPage.mock.calls[0][0]).toEqual(20);
+
+        expect(mockOnPageChange.mock.calls[0][0]).toEqual({
+          page: 0,
+          start: 0,
+          rowsPerPage: 20
+        });
       });
     });
   });

--- a/src/table/src/components/Table.js
+++ b/src/table/src/components/Table.js
@@ -26,8 +26,15 @@ type Props = {
   exact ?:boolean;
   headers :Array<Object>;
   isLoading :boolean;
-  onPageChange ?:(payload :any) => void;
-  onSort ?:(column :string, isDescending :boolean) => void;
+  onPageChange ?:({
+    page :number,
+    start :number,
+    rowsPerPage :number
+  }) => void;
+  onSort ?:({
+    column :string,
+    descending :boolean
+  }) => void;
   paginated ? :boolean;
   rowsPerPageOptions :number[];
   totalRows ?:number;
@@ -62,11 +69,11 @@ const Table = (props :Props) => {
     }
   }, [rowCount, rowsPerPageOptions]);
 
-  const handleSort = useCallback((event, property) => {
-    const isDesc = orderBy === property && order === 'desc';
+  const handleSort = useCallback((event, column) => {
+    const isDesc = orderBy === column && order === 'desc';
     setOrder(isDesc ? 'asc' : 'desc');
-    setOrderBy(property);
-    if (isFunction(onSort)) onSort(property, !isDesc);
+    setOrderBy(column);
+    if (isFunction(onSort)) onSort({ column, descending: !isDesc });
   }, [onSort, order, orderBy]);
 
   const components = { ...defaultComponents, ...propComponents };

--- a/src/table/src/components/Table.js
+++ b/src/table/src/components/Table.js
@@ -20,21 +20,22 @@ const defaultComponents = {
   Row: TableRow,
 };
 
+type ChangeHandler = ? ({
+  column ?:string,
+  order ?:'asc' | 'desc',
+  page :number,
+  rowsPerPage :number,
+  start :number,
+}) => void;
+
 type Props = {
   components :Object;
   data :Array<Object>;
   exact ?:boolean;
   headers :Array<Object>;
   isLoading :boolean;
-  onPageChange ?:({
-    page :number,
-    start :number,
-    rowsPerPage :number
-  }) => void;
-  onSort ?:({
-    column :string,
-    descending :boolean
-  }) => void;
+  onPageChange :ChangeHandler;
+  onSort :ChangeHandler;
   paginated ? :boolean;
   rowsPerPageOptions :number[];
   totalRows ?:number;
@@ -71,12 +72,13 @@ const Table = (props :Props) => {
 
   const handleSort = useCallback((column :string, event :SyntheticEvent<HTMLTableCellElement>) => {
     const isDesc = orderBy === column && order === 'desc';
-    setOrder(isDesc ? 'asc' : 'desc');
+    const newOrder = isDesc ? 'asc' : 'desc';
+    setOrder(newOrder);
     setOrderBy(column);
     if (isFunction(onSort)) {
       onSort({
         column,
-        descending: !isDesc,
+        order: newOrder,
         page: currentPage,
         rowsPerPage,
         start: Math.min(currentPage * rowsPerPage, rowCount)
@@ -99,7 +101,7 @@ const Table = (props :Props) => {
       onPageChange({
         ...payload,
         column: orderBy,
-        descending: order,
+        order,
       }, event);
     }
   }, [

--- a/src/table/src/components/Table.js
+++ b/src/table/src/components/Table.js
@@ -97,18 +97,15 @@ const Table = (props :Props) => {
     setRowsPerPage(newRowsPerPage);
     if (isFunction(onPageChange)) {
       onPageChange({
+        ...payload,
         column: orderBy,
         descending: order,
-        page: newPage,
-        rowsPerPage: newRowsPerPage,
-        start: Math.min(newPage * newRowsPerPage, rowCount)
       }, event);
     }
   }, [
     onPageChange,
     order,
-    orderBy,
-    rowCount,
+    orderBy
   ]);
 
   const components = { ...defaultComponents, ...propComponents };

--- a/src/table/src/components/Table.js
+++ b/src/table/src/components/Table.js
@@ -69,12 +69,47 @@ const Table = (props :Props) => {
     }
   }, [rowCount, rowsPerPageOptions]);
 
-  const handleSort = useCallback((event, column) => {
+  const handleSort = useCallback((column :string, event :SyntheticEvent<HTMLTableCellElement>) => {
     const isDesc = orderBy === column && order === 'desc';
     setOrder(isDesc ? 'asc' : 'desc');
     setOrderBy(column);
-    if (isFunction(onSort)) onSort({ column, descending: !isDesc });
-  }, [onSort, order, orderBy]);
+    if (isFunction(onSort)) {
+      onSort({
+        column,
+        descending: !isDesc,
+        page: currentPage,
+        rowsPerPage,
+        start: Math.min(currentPage * rowsPerPage, rowCount)
+      }, event);
+    }
+  }, [
+    currentPage,
+    rowsPerPage,
+    rowCount,
+    onSort,
+    order,
+    orderBy
+  ]);
+
+  const handlePageChange = useCallback((payload, event) => {
+    const { page: newPage, rowsPerPage: newRowsPerPage } = payload;
+    setPage(newPage);
+    setRowsPerPage(newRowsPerPage);
+    if (isFunction(onPageChange)) {
+      onPageChange({
+        column: orderBy,
+        descending: order,
+        page: newPage,
+        rowsPerPage: newRowsPerPage,
+        start: Math.min(newPage * newRowsPerPage, rowCount)
+      }, event);
+    }
+  }, [
+    onPageChange,
+    order,
+    orderBy,
+    rowCount,
+  ]);
 
   const components = { ...defaultComponents, ...propComponents };
   return (
@@ -83,12 +118,10 @@ const Table = (props :Props) => {
         paginated && (
           <components.Pagination
               count={rowCount}
-              onPageChange={onPageChange}
+              onPageChange={handlePageChange}
               page={currentPage}
               rowsPerPage={rowsPerPage}
-              rowsPerPageOptions={rowsPerPageOptions}
-              setRowsPerPage={setRowsPerPage}
-              setPage={setPage} />
+              rowsPerPageOptions={rowsPerPageOptions} />
         )
       }
       <StyledTable>
@@ -114,12 +147,10 @@ const Table = (props :Props) => {
         paginated && (
           <components.Pagination
               count={rowCount}
-              onPageChange={onPageChange}
+              onPageChange={handlePageChange}
               page={currentPage}
               rowsPerPage={rowsPerPage}
-              rowsPerPageOptions={rowsPerPageOptions}
-              setRowsPerPage={setRowsPerPage}
-              setPage={setPage} />
+              rowsPerPageOptions={rowsPerPageOptions} />
         )
       }
     </div>

--- a/src/table/src/components/Table.test.js
+++ b/src/table/src/components/Table.test.js
@@ -92,6 +92,26 @@ describe('Table', () => {
       expect(setState.mock.calls[3][0]).toEqual('name');
       expect(toJson(wrapper)).toMatchSnapshot();
     });
+
+    test('should invoke onSort with property and isDesc', () => {
+      const onSort = jest.fn();
+
+      const wrapper = mount(
+        <Table
+            data={TABLE_DATA}
+            headers={TABLE_HEADERS}
+            onSort={onSort}
+            paginated />
+      );
+
+      act(() => {
+        wrapper.find('Cell').get(0).props.onClick();
+      });
+
+      expect(onSort.mock.calls[0][0]).toEqual('name');
+      expect(onSort.mock.calls[0][1]).toEqual(true);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
   });
 
   describe('render', () => {

--- a/src/table/src/components/Table.test.js
+++ b/src/table/src/components/Table.test.js
@@ -112,7 +112,7 @@ describe('Table', () => {
 
       expect(mockOnSort.mock.calls[0][0]).toEqual({
         column: 'name',
-        descending: true,
+        order: 'desc',
         page: 0,
         rowsPerPage: 7,
         start: 0
@@ -163,7 +163,7 @@ describe('Table', () => {
       expect(mockOnPageChange).toBeCalledTimes(1);
       expect(mockOnPageChange.mock.calls[0][0]).toEqual({
         column: undefined,
-        descending: undefined,
+        order: undefined,
         page: 1,
         rowsPerPage: 7,
         start: 7
@@ -191,7 +191,7 @@ describe('Table', () => {
       expect(mockOnPageChange).toBeCalledTimes(1);
       expect(mockOnPageChange.mock.calls[0][0]).toEqual({
         column: undefined,
-        descending: undefined,
+        order: undefined,
         page: 0,
         rowsPerPage: 20,
         start: 0

--- a/src/table/src/components/Table.test.js
+++ b/src/table/src/components/Table.test.js
@@ -7,7 +7,9 @@ import Table from './Table';
 import TableBody from './TableBody';
 import PaginationToolbar from './PaginationToolbar';
 import { StyledTable } from './styled';
+import { Select } from '../../../select';
 import { TABLE_DATA, TABLE_HEADERS } from '../../stories/constants';
+import { MOCK_CLICK_EVENT, MOCK_SELECT_EVENT } from '../../../utils/testing/MockUtils';
 
 describe('Table', () => {
 
@@ -85,33 +87,116 @@ describe('Table', () => {
       );
 
       act(() => {
-        wrapper.find('Cell').get(0).props.onClick();
+        wrapper.find('Cell').get(0).props.onClick(MOCK_CLICK_EVENT);
       });
 
-      expect(setState.mock.calls[2][0]).toEqual('desc');
-      expect(setState.mock.calls[3][0]).toEqual('name');
+      expect(setState.mock.calls[2][0]).toEqual('desc'); // setOrder
+      expect(setState.mock.calls[3][0]).toEqual('name'); // setOrderBy
       expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     test('should invoke onSort with property and isDesc', () => {
-      const onSort = jest.fn();
+      const mockOnSort = jest.fn();
 
       const wrapper = mount(
         <Table
             data={TABLE_DATA}
             headers={TABLE_HEADERS}
-            onSort={onSort}
+            onSort={mockOnSort}
             paginated />
       );
 
       act(() => {
-        wrapper.find('Cell').get(0).props.onClick();
+        wrapper.find('Cell').get(0).props.onClick(MOCK_CLICK_EVENT);
       });
 
-      expect(onSort.mock.calls[0][0]).toEqual({
+      expect(mockOnSort.mock.calls[0][0]).toEqual({
         column: 'name',
-        descending: true
+        descending: true,
+        page: 0,
+        rowsPerPage: 7,
+        start: 0
       });
+      expect(mockOnSort).toMatchSnapshot();
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
+  describe('handlePageChange', () => {
+
+    test('should set page and rowsPerPage when invoked', () => {
+      const setState = jest.fn();
+      const useStateSpy = jest.spyOn(React, 'useState');
+      useStateSpy.mockImplementation((init) => [init, setState]);
+
+      const wrapper = mount(
+        <Table
+            data={TABLE_DATA}
+            headers={TABLE_HEADERS}
+            paginated />
+      );
+
+      act(() => {
+        wrapper.find('IconButton').get(1).props.onClick(MOCK_CLICK_EVENT);
+      });
+
+      expect(setState.mock.calls[2][0]).toEqual(1); // setPage
+      expect(setState.mock.calls[3][0]).toEqual(7); // setRowsPerPage
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    test('should invoke onPageChange on pagination button click', () => {
+      const mockOnPageChange = jest.fn();
+
+      const wrapper = mount(
+        <Table
+            data={TABLE_DATA}
+            headers={TABLE_HEADERS}
+            onPageChange={mockOnPageChange}
+            paginated />
+      );
+
+      act(() => {
+        wrapper.find('IconButton').get(1).props.onClick(MOCK_CLICK_EVENT);
+      });
+
+      expect(mockOnPageChange).toBeCalledTimes(1);
+      expect(mockOnPageChange.mock.calls[0][0]).toEqual({
+        column: undefined,
+        descending: undefined,
+        page: 1,
+        rowsPerPage: 7,
+        start: 7
+      });
+      expect(mockOnPageChange).toMatchSnapshot();
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    test('should invoke onPageChange on rows per page select', () => {
+      const mockOnPageChange = jest.fn();
+
+      const wrapper = mount(
+        <Table
+            data={TABLE_DATA}
+            headers={TABLE_HEADERS}
+            rowsPerPageOptions={[5, 20, 50]}
+            onPageChange={mockOnPageChange}
+            paginated />
+      );
+
+      act(() => {
+        wrapper.find(Select).get(0).props.onChange(20, MOCK_SELECT_EVENT);
+      });
+
+      expect(mockOnPageChange).toBeCalledTimes(1);
+      expect(mockOnPageChange.mock.calls[0][0]).toEqual({
+        column: undefined,
+        descending: undefined,
+        page: 0,
+        rowsPerPage: 20,
+        start: 0
+      });
+      expect(mockOnPageChange).toMatchSnapshot();
       expect(toJson(wrapper)).toMatchSnapshot();
     });
   });

--- a/src/table/src/components/Table.test.js
+++ b/src/table/src/components/Table.test.js
@@ -108,8 +108,10 @@ describe('Table', () => {
         wrapper.find('Cell').get(0).props.onClick();
       });
 
-      expect(onSort.mock.calls[0][0]).toEqual('name');
-      expect(onSort.mock.calls[0][1]).toEqual(true);
+      expect(onSort.mock.calls[0][0]).toEqual({
+        column: 'name',
+        descending: true
+      });
       expect(toJson(wrapper)).toMatchSnapshot();
     });
   });

--- a/src/table/src/components/TableBody.js
+++ b/src/table/src/components/TableBody.js
@@ -10,7 +10,8 @@ import type { RowData, SortOrder } from '../../types';
 type Props = {
   className ? :string;
   components :Object;
-  data ? :RowData[];
+  data :RowData[];
+  exact ? :boolean;
   headers :Object[];
   isLoading ? :boolean;
   order ? :SortOrder;
@@ -26,6 +27,7 @@ const TableBody = (props :Props) => {
     data,
     headers,
     isLoading,
+    exact,
     order,
     orderBy,
     page,
@@ -33,7 +35,9 @@ const TableBody = (props :Props) => {
   } = props;
 
   const sortedData = getSortedData(headers, data, order, orderBy);
-  const dataByPage :RowData[] = sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
+  const dataByPage :RowData[] = exact
+    ? sortedData
+    : sortedData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
 
   // inject empty row to maintain table size
   const emptyRowCount = rowsPerPage - dataByPage.length;
@@ -87,6 +91,7 @@ TableBody.defaultProps = {
   className: undefined,
   data: [],
   isLoading: false,
+  exact: false,
   order: false,
   orderBy: undefined
 };

--- a/src/table/src/components/TableHeader.js
+++ b/src/table/src/components/TableHeader.js
@@ -9,7 +9,7 @@ type Props = {
   className ? :string;
   components :Object;
   headers ? :Object[];
-  onSort ? :(event :SyntheticEvent<HTMLElement>, property :string) => void;
+  onSort ? :(property :string, event :SyntheticEvent<HTMLTableCellElement>) => void;
   order ? :SortOrder;
   orderBy ? :string;
   sticky ? :boolean;
@@ -27,9 +27,9 @@ const TableHeader = (props :Props) => {
     sticky,
   } = props;
 
-  const createSortHandler = (property :string) => (event :SyntheticEvent<HTMLElement>) => {
+  const createSortHandler = (property :string) => (event :SyntheticEvent<HTMLTableCellElement>) => {
     if (isFunction(onSort)) {
-      onSort(event, property);
+      onSort(property, event);
     }
   };
 

--- a/src/table/src/components/TableHeader.test.js
+++ b/src/table/src/components/TableHeader.test.js
@@ -4,8 +4,9 @@ import toJson from 'enzyme-to-json';
 
 import TableHeader from './TableHeader';
 import { StyledRow } from './styled';
-import { TABLE_HEADERS } from '../../stories/constants';
 import HeadCell from './HeadCell';
+import { TABLE_HEADERS } from '../../stories/constants';
+import { MOCK_CLICK_EVENT } from '../../../utils/testing/MockUtils';
 
 describe('TableHeader', () => {
 
@@ -34,13 +35,11 @@ describe('TableHeader', () => {
         const headerCells = wrapper.find(HeadCell);
         expect(mockOnSort).toHaveBeenCalledTimes(0);
 
-        headerCells.get(0).props.onClick();
+        headerCells.get(0).props.onClick(MOCK_CLICK_EVENT);
         expect(mockOnSort).toHaveBeenCalledTimes(1);
-        expect(mockOnSort.mock.calls[0][1]).toEqual('name');
+        expect(mockOnSort).toBeCalledWith('name', MOCK_CLICK_EVENT);
 
-        headerCells.get(1).props.onClick();
-        expect(mockOnSort).toHaveBeenCalledTimes(2);
-        expect(mockOnSort.mock.calls[1][1]).toEqual('dob');
+        expect(mockOnSort).toMatchSnapshot();
         expect(toJson(wrapper)).toMatchSnapshot();
       });
     });

--- a/src/table/src/components/__snapshots__/Table.test.js.snap
+++ b/src/table/src/components/__snapshots__/Table.test.js.snap
@@ -1,6 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
+exports[`Table handlePageChange should invoke onPageChange on pagination button click 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "column": undefined,
+        "descending": undefined,
+        "page": 1,
+        "rowsPerPage": 7,
+        "start": 7,
+      },
+      Object {
+        "target": "mock",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Table handlePageChange should invoke onPageChange on pagination button click 2`] = `
 .c5 {
   background-color: #ffffff;
   border-collapse: collapse;
@@ -250,13 +275,19 @@ exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
       },
     ]
   }
-  onSort={
+  onPageChange={
     [MockFunction] {
       "calls": Array [
         Array [
           Object {
-            "column": "name",
-            "descending": true,
+            "column": undefined,
+            "descending": undefined,
+            "page": 1,
+            "rowsPerPage": 7,
+            "start": 7,
+          },
+          Object {
+            "target": "mock",
           },
         ],
       ],
@@ -273,137 +304,10 @@ exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
   <div>
     <PaginationToolbar
       count={7}
+      onPageChange={[Function]}
       page={0}
       rowsPerPage={7}
       rowsPerPageOptions={Array []}
-      setPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setRowsPerPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
     >
       <styled__PaginationWrapper>
         <StyledComponent
@@ -4010,137 +3914,16289 @@ exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
     </styled__StyledTable>
     <PaginationToolbar
       count={7}
+      onPageChange={[Function]}
       page={0}
       rowsPerPage={7}
       rowsPerPageOptions={Array []}
-      setPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
             Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 7 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+  </div>
+</Table>
+`;
+
+exports[`Table handlePageChange should invoke onPageChange on rows per page select 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "column": undefined,
+        "descending": undefined,
+        "page": 0,
+        "rowsPerPage": 20,
+        "start": 0,
+      },
+      Object {
+        "action": "select-option",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Table handlePageChange should invoke onPageChange on rows per page select 2`] = `
+.c6 {
+  background-color: #ffffff;
+  border-collapse: collapse;
+  border: none;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.c8 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+  width: 33%;
+}
+
+.c9 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c10 {
+  background-color: #f0f0f7;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c12 {
+  background-color: inherit;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c7 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c7 td,
+.c7 th {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 200;
+}
+
+.c11 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c2 {
+  font-size: 14px;
+  margin-right: 10px;
+  width: 75px;
+}
+
+.c4 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  position: relative;
+  overflow: hidden;
+  min-width: 14px;
+}
+
+.c5 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  opacity: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c3 {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 18px;
+  outline: none;
+  padding: 10px 20px;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  white-space: nowrap;
+  background-color: transparent;
+  border-color: transparent;
+  color: #6124e2;
+}
+
+.c3:hover {
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.1);
+}
+
+.c3:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.15);
+}
+
+.c3:disabled {
+  cursor: not-allowed;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  border-color: transparent;
+  color: #b6bbc7;
+}
+
+.c3:focus-visible {
+  box-shadow: rgba(0,0,0,0.15) 0 0 0 2px;
+}
+
+.c1 {
+  color: #555e6f;
+  display: inline-block;
+  font-size: 14px;
+  font-stretch: normal;
+  font-style: normal;
+  font-weight: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  margin: 5px 5px 5px 0;
+  color: #8e929b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+<Table
+  data={
+    Array [
+      Object {
+        "dob": "1942-11-30",
+        "id": "1",
+        "lastUpdated": "2019-09-01",
+        "manager": "Spongebob",
+        "name": "Eugene Krabs",
+      },
+      Object {
+        "dob": "",
+        "id": "2",
+        "lastUpdated": "2019-08-29",
+        "manager": "Smitty",
+        "name": "Squidward Tentacles",
+      },
+      Object {
+        "dob": "1987-11-17",
+        "id": "3",
+        "lastUpdated": "2019-07-30",
+        "manager": "Patrick",
+        "name": "Sandy Cheeks",
+      },
+      Object {
+        "dob": "1975-06-23",
+        "id": "4",
+        "lastUpdated": "2019-08-16",
+        "manager": "Patchy",
+        "name": "Larry the Lobster",
+      },
+      Object {
+        "dob": "1942-11-30",
+        "id": "5",
+        "lastUpdated": "2019-08-20",
+        "manager": "Spongebob",
+        "name": "Sheldon Plankton",
+      },
+      Object {
+        "dob": "",
+        "id": "6",
+        "lastUpdated": "2019-08-21",
+        "manager": "Spongebob",
+        "name": "Mrs. Puff",
+      },
+      Object {
+        "dob": "1678-04-20",
+        "id": "7",
+        "lastUpdated": "2019-06-21",
+        "manager": "Spongebob",
+        "name": "Flying Dutchman",
+      },
+    ]
+  }
+  headers={
+    Array [
+      Object {
+        "cellStyle": Object {
+          "width": "33%",
+        },
+        "key": "name",
+        "label": "Subject Name",
+      },
+      Object {
+        "key": "dob",
+        "label": "Date of Birth",
+      },
+      Object {
+        "key": "manager",
+        "label": "Manager",
+      },
+      Object {
+        "key": "lastUpdated",
+        "label": "Last Updated",
+      },
+      Object {
+        "key": "id",
+        "label": "ID",
+        "sortable": false,
+      },
+    ]
+  }
+  onPageChange={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "column": undefined,
+            "descending": undefined,
+            "page": 0,
+            "rowsPerPage": 20,
+            "start": 0,
+          },
+          Object {
+            "action": "select-option",
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  paginated={true}
+  rowsPerPageOptions={
+    Array [
+      5,
+      20,
+      50,
+    ]
+  }
+>
+  <div>
+    <PaginationToolbar
+      count={7}
+      onPageChange={[Function]}
+      page={0}
+      rowsPerPage={5}
+      rowsPerPageOptions={
+        Array [
+          5,
+          20,
+          50,
+        ]
       }
-      setRowsPerPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
             Object {
-              "type": "return",
-              "value": undefined,
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <styled__RowPerPageWrapper>
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "styled__RowPerPageWrapper-r3xwjs-4",
+                      "isStatic": false,
+                      "lastClassName": "c2",
+                      "rules": Array [
+                        "font-size:14px;margin-right:10px;width:75px;",
+                      ],
+                    },
+                    "displayName": "styled__RowPerPageWrapper",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "styled__RowPerPageWrapper-r3xwjs-4",
+                    "target": "div",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+              >
+                <div
+                  className="c2"
+                >
+                  <Select
+                    borderless={true}
+                    defaultValue={
+                      Object {
+                        "label": "5",
+                        "value": 5,
+                      }
+                    }
+                    onChange={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "label": "5",
+                          "value": 5,
+                        },
+                        Object {
+                          "label": "20",
+                          "value": 20,
+                        },
+                        Object {
+                          "label": "50",
+                          "value": 50,
+                        },
+                      ]
+                    }
+                    useRawValues={true}
+                    value={5}
+                  >
+                    <SelectController
+                      borderless={true}
+                      defaultValue={
+                        Object {
+                          "label": "5",
+                          "value": 5,
+                        }
+                      }
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "5",
+                            "value": 5,
+                          },
+                          Object {
+                            "label": "20",
+                            "value": 20,
+                          },
+                          Object {
+                            "label": "50",
+                            "value": 50,
+                          },
+                        ]
+                      }
+                      render={[Function]}
+                      useRawValues={true}
+                      value={5}
+                    >
+                      <StateManager
+                        borderless={true}
+                        components={
+                          Object {
+                            "Option": [Function],
+                          }
+                        }
+                        defaultInputValue=""
+                        defaultMenuIsOpen={false}
+                        defaultValue={
+                          Object {
+                            "label": "5",
+                            "value": 5,
+                          }
+                        }
+                        filterOption={[Function]}
+                        menuPlacement="auto"
+                        onChange={[Function]}
+                        options={
+                          Array [
+                            Object {
+                              "label": "5",
+                              "value": 5,
+                            },
+                            Object {
+                              "label": "20",
+                              "value": 20,
+                            },
+                            Object {
+                              "label": "50",
+                              "value": 50,
+                            },
+                          ]
+                        }
+                        styles={
+                          Object {
+                            "clearIndicator": [Function],
+                            "container": [Function],
+                            "control": [Function],
+                            "dropdownIndicator": [Function],
+                            "indicatorSeparator": [Function],
+                            "indicatorsContainer": [Function],
+                            "menu": [Function],
+                            "menuList": [Function],
+                            "menuPortal": [Function],
+                            "option": [Function],
+                            "singleValue": [Function],
+                            "valueContainer": [Function],
+                          }
+                        }
+                        value={
+                          Object {
+                            "label": "5",
+                            "value": 5,
+                          }
+                        }
+                      >
+                        <Select
+                          backspaceRemovesValue={true}
+                          blurInputOnSelect={true}
+                          borderless={true}
+                          captureMenuScroll={false}
+                          closeMenuOnScroll={false}
+                          closeMenuOnSelect={true}
+                          components={
+                            Object {
+                              "Option": [Function],
+                            }
+                          }
+                          controlShouldRenderValue={true}
+                          escapeClearsValue={false}
+                          filterOption={[Function]}
+                          formatGroupLabel={[Function]}
+                          getOptionLabel={[Function]}
+                          getOptionValue={[Function]}
+                          inputValue=""
+                          isDisabled={false}
+                          isLoading={false}
+                          isMulti={false}
+                          isOptionDisabled={[Function]}
+                          isRtl={false}
+                          isSearchable={true}
+                          loadingMessage={[Function]}
+                          maxMenuHeight={300}
+                          menuIsOpen={false}
+                          menuPlacement="auto"
+                          menuPosition="absolute"
+                          menuShouldBlockScroll={false}
+                          menuShouldScrollIntoView={true}
+                          minMenuHeight={140}
+                          noOptionsMessage={[Function]}
+                          onChange={[Function]}
+                          onInputChange={[Function]}
+                          onMenuClose={[Function]}
+                          onMenuOpen={[Function]}
+                          openMenuOnClick={true}
+                          openMenuOnFocus={false}
+                          options={
+                            Array [
+                              Object {
+                                "label": "5",
+                                "value": 5,
+                              },
+                              Object {
+                                "label": "20",
+                                "value": 20,
+                              },
+                              Object {
+                                "label": "50",
+                                "value": 50,
+                              },
+                            ]
+                          }
+                          pageSize={5}
+                          placeholder="Select..."
+                          screenReaderStatus={[Function]}
+                          styles={
+                            Object {
+                              "clearIndicator": [Function],
+                              "container": [Function],
+                              "control": [Function],
+                              "dropdownIndicator": [Function],
+                              "indicatorSeparator": [Function],
+                              "indicatorsContainer": [Function],
+                              "menu": [Function],
+                              "menuList": [Function],
+                              "menuPortal": [Function],
+                              "option": [Function],
+                              "singleValue": [Function],
+                              "valueContainer": [Function],
+                            }
+                          }
+                          tabIndex="0"
+                          tabSelectsValue={true}
+                          value={
+                            Object {
+                              "label": "5",
+                              "value": 5,
+                            }
+                          }
+                        >
+                          <SelectContainer
+                            clearValue={[Function]}
+                            cx={[Function]}
+                            getStyles={[Function]}
+                            getValue={[Function]}
+                            hasValue={true}
+                            innerProps={
+                              Object {
+                                "id": undefined,
+                                "onKeyDown": [Function],
+                              }
+                            }
+                            isDisabled={false}
+                            isFocused={false}
+                            isMulti={false}
+                            isRtl={false}
+                            options={
+                              Array [
+                                Object {
+                                  "label": "5",
+                                  "value": 5,
+                                },
+                                Object {
+                                  "label": "20",
+                                  "value": 20,
+                                },
+                                Object {
+                                  "label": "50",
+                                  "value": 50,
+                                },
+                              ]
+                            }
+                            selectOption={[Function]}
+                            selectProps={
+                              Object {
+                                "backspaceRemovesValue": true,
+                                "blurInputOnSelect": true,
+                                "borderless": true,
+                                "captureMenuScroll": false,
+                                "closeMenuOnScroll": false,
+                                "closeMenuOnSelect": true,
+                                "components": Object {
+                                  "Option": [Function],
+                                },
+                                "controlShouldRenderValue": true,
+                                "escapeClearsValue": false,
+                                "filterOption": [Function],
+                                "formatGroupLabel": [Function],
+                                "getOptionLabel": [Function],
+                                "getOptionValue": [Function],
+                                "icon": undefined,
+                                "inputValue": "",
+                                "isDisabled": false,
+                                "isLoading": false,
+                                "isMulti": false,
+                                "isOptionDisabled": [Function],
+                                "isRtl": false,
+                                "isSearchable": true,
+                                "loadingMessage": [Function],
+                                "maxMenuHeight": 300,
+                                "menuIsOpen": false,
+                                "menuPlacement": "auto",
+                                "menuPosition": "absolute",
+                                "menuShouldBlockScroll": false,
+                                "menuShouldScrollIntoView": true,
+                                "minMenuHeight": 140,
+                                "noOptionsMessage": [Function],
+                                "onChange": [Function],
+                                "onInputChange": [Function],
+                                "onMenuClose": [Function],
+                                "onMenuOpen": [Function],
+                                "openMenuOnClick": true,
+                                "openMenuOnFocus": false,
+                                "options": Array [
+                                  Object {
+                                    "label": "5",
+                                    "value": 5,
+                                  },
+                                  Object {
+                                    "label": "20",
+                                    "value": 20,
+                                  },
+                                  Object {
+                                    "label": "50",
+                                    "value": 50,
+                                  },
+                                ],
+                                "pageSize": 5,
+                                "placeholder": "Select...",
+                                "screenReaderStatus": [Function],
+                                "styles": Object {
+                                  "clearIndicator": [Function],
+                                  "container": [Function],
+                                  "control": [Function],
+                                  "dropdownIndicator": [Function],
+                                  "indicatorSeparator": [Function],
+                                  "indicatorsContainer": [Function],
+                                  "menu": [Function],
+                                  "menuList": [Function],
+                                  "menuPortal": [Function],
+                                  "option": [Function],
+                                  "singleValue": [Function],
+                                  "valueContainer": [Function],
+                                },
+                                "tabIndex": "0",
+                                "tabSelectsValue": true,
+                                "value": Object {
+                                  "label": "5",
+                                  "value": 5,
+                                },
+                              }
+                            }
+                            setValue={[Function]}
+                            theme={
+                              Object {
+                                "borderRadius": 4,
+                                "colors": Object {
+                                  "danger": "#DE350B",
+                                  "dangerLight": "#FFBDAD",
+                                  "neutral0": "hsl(0, 0%, 100%)",
+                                  "neutral10": "hsl(0, 0%, 90%)",
+                                  "neutral20": "hsl(0, 0%, 80%)",
+                                  "neutral30": "hsl(0, 0%, 70%)",
+                                  "neutral40": "hsl(0, 0%, 60%)",
+                                  "neutral5": "hsl(0, 0%, 95%)",
+                                  "neutral50": "hsl(0, 0%, 50%)",
+                                  "neutral60": "hsl(0, 0%, 40%)",
+                                  "neutral70": "hsl(0, 0%, 30%)",
+                                  "neutral80": "hsl(0, 0%, 20%)",
+                                  "neutral90": "hsl(0, 0%, 10%)",
+                                  "primary": "#2684FF",
+                                  "primary25": "#DEEBFF",
+                                  "primary50": "#B2D4FF",
+                                  "primary75": "#4C9AFF",
+                                },
+                                "spacing": Object {
+                                  "baseUnit": 4,
+                                  "controlHeight": 38,
+                                  "menuGutter": 8,
+                                },
+                              }
+                            }
+                          >
+                            <EmotionCssPropInternal
+                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SelectContainer"
+                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                              className=""
+                              css={
+                                Object {
+                                  "boxSizing": "border-box",
+                                  "cursor": "default",
+                                  "direction": null,
+                                  "label": "container",
+                                  "pointerEvents": "auto",
+                                  "position": "relative",
+                                  "width": "100%",
+                                }
+                              }
+                              onKeyDown={[Function]}
+                            >
+                              <div
+                                className=" css-gprrux-container"
+                                onKeyDown={[Function]}
+                              >
+                                <Control
+                                  clearValue={[Function]}
+                                  cx={[Function]}
+                                  getStyles={[Function]}
+                                  getValue={[Function]}
+                                  hasValue={true}
+                                  innerProps={
+                                    Object {
+                                      "onMouseDown": [Function],
+                                      "onTouchEnd": [Function],
+                                    }
+                                  }
+                                  innerRef={[Function]}
+                                  isDisabled={false}
+                                  isFocused={false}
+                                  isMulti={false}
+                                  isRtl={false}
+                                  menuIsOpen={false}
+                                  options={
+                                    Array [
+                                      Object {
+                                        "label": "5",
+                                        "value": 5,
+                                      },
+                                      Object {
+                                        "label": "20",
+                                        "value": 20,
+                                      },
+                                      Object {
+                                        "label": "50",
+                                        "value": 50,
+                                      },
+                                    ]
+                                  }
+                                  selectOption={[Function]}
+                                  selectProps={
+                                    Object {
+                                      "backspaceRemovesValue": true,
+                                      "blurInputOnSelect": true,
+                                      "borderless": true,
+                                      "captureMenuScroll": false,
+                                      "closeMenuOnScroll": false,
+                                      "closeMenuOnSelect": true,
+                                      "components": Object {
+                                        "Option": [Function],
+                                      },
+                                      "controlShouldRenderValue": true,
+                                      "escapeClearsValue": false,
+                                      "filterOption": [Function],
+                                      "formatGroupLabel": [Function],
+                                      "getOptionLabel": [Function],
+                                      "getOptionValue": [Function],
+                                      "icon": undefined,
+                                      "inputValue": "",
+                                      "isDisabled": false,
+                                      "isLoading": false,
+                                      "isMulti": false,
+                                      "isOptionDisabled": [Function],
+                                      "isRtl": false,
+                                      "isSearchable": true,
+                                      "loadingMessage": [Function],
+                                      "maxMenuHeight": 300,
+                                      "menuIsOpen": false,
+                                      "menuPlacement": "auto",
+                                      "menuPosition": "absolute",
+                                      "menuShouldBlockScroll": false,
+                                      "menuShouldScrollIntoView": true,
+                                      "minMenuHeight": 140,
+                                      "noOptionsMessage": [Function],
+                                      "onChange": [Function],
+                                      "onInputChange": [Function],
+                                      "onMenuClose": [Function],
+                                      "onMenuOpen": [Function],
+                                      "openMenuOnClick": true,
+                                      "openMenuOnFocus": false,
+                                      "options": Array [
+                                        Object {
+                                          "label": "5",
+                                          "value": 5,
+                                        },
+                                        Object {
+                                          "label": "20",
+                                          "value": 20,
+                                        },
+                                        Object {
+                                          "label": "50",
+                                          "value": 50,
+                                        },
+                                      ],
+                                      "pageSize": 5,
+                                      "placeholder": "Select...",
+                                      "screenReaderStatus": [Function],
+                                      "styles": Object {
+                                        "clearIndicator": [Function],
+                                        "container": [Function],
+                                        "control": [Function],
+                                        "dropdownIndicator": [Function],
+                                        "indicatorSeparator": [Function],
+                                        "indicatorsContainer": [Function],
+                                        "menu": [Function],
+                                        "menuList": [Function],
+                                        "menuPortal": [Function],
+                                        "option": [Function],
+                                        "singleValue": [Function],
+                                        "valueContainer": [Function],
+                                      },
+                                      "tabIndex": "0",
+                                      "tabSelectsValue": true,
+                                      "value": Object {
+                                        "label": "5",
+                                        "value": 5,
+                                      },
+                                    }
+                                  }
+                                  setValue={[Function]}
+                                  theme={
+                                    Object {
+                                      "borderRadius": 4,
+                                      "colors": Object {
+                                        "danger": "#DE350B",
+                                        "dangerLight": "#FFBDAD",
+                                        "neutral0": "hsl(0, 0%, 100%)",
+                                        "neutral10": "hsl(0, 0%, 90%)",
+                                        "neutral20": "hsl(0, 0%, 80%)",
+                                        "neutral30": "hsl(0, 0%, 70%)",
+                                        "neutral40": "hsl(0, 0%, 60%)",
+                                        "neutral5": "hsl(0, 0%, 95%)",
+                                        "neutral50": "hsl(0, 0%, 50%)",
+                                        "neutral60": "hsl(0, 0%, 40%)",
+                                        "neutral70": "hsl(0, 0%, 30%)",
+                                        "neutral80": "hsl(0, 0%, 20%)",
+                                        "neutral90": "hsl(0, 0%, 10%)",
+                                        "primary": "#2684FF",
+                                        "primary25": "#DEEBFF",
+                                        "primary50": "#B2D4FF",
+                                        "primary75": "#4C9AFF",
+                                      },
+                                      "spacing": Object {
+                                        "baseUnit": 4,
+                                        "controlHeight": 38,
+                                        "menuGutter": 8,
+                                      },
+                                    }
+                                  }
+                                >
+                                  <EmotionCssPropInternal
+                                    __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Control"
+                                    __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                    className=""
+                                    css={
+                                      Object {
+                                        "&:hover": Object {
+                                          "borderColor": "hsl(0, 0%, 70%)",
+                                        },
+                                        ":hover": Object {
+                                          "backgroundColor": "#f0f0f7",
+                                          "border": "none",
+                                        },
+                                        "alignItems": "center",
+                                        "backgroundColor": "transparent",
+                                        "border": "none",
+                                        "borderColor": "hsl(0, 0%, 80%)",
+                                        "borderRadius": "3px",
+                                        "borderStyle": "solid",
+                                        "borderWidth": 1,
+                                        "boxShadow": "none",
+                                        "boxSizing": "border-box",
+                                        "cursor": "default",
+                                        "display": "flex",
+                                        "flexWrap": "wrap",
+                                        "fontSize": "14px",
+                                        "justifyContent": "space-between",
+                                        "label": "control",
+                                        "lineHeight": 1.5,
+                                        "minHeight": "40px",
+                                        "outline": "0 !important",
+                                        "pointerEvents": "auto",
+                                        "position": "relative",
+                                        "transition": "background-color 0.2s ease-out, border-color 0.2s ease-out",
+                                      }
+                                    }
+                                    onMouseDown={[Function]}
+                                    onTouchEnd={[Function]}
+                                  >
+                                    <div
+                                      className=" css-1ugvnb2-control"
+                                      onMouseDown={[Function]}
+                                      onTouchEnd={[Function]}
+                                    >
+                                      <ValueContainer
+                                        clearValue={[Function]}
+                                        cx={[Function]}
+                                        getStyles={[Function]}
+                                        getValue={[Function]}
+                                        hasValue={true}
+                                        isDisabled={false}
+                                        isMulti={false}
+                                        isRtl={false}
+                                        options={
+                                          Array [
+                                            Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                            Object {
+                                              "label": "20",
+                                              "value": 20,
+                                            },
+                                            Object {
+                                              "label": "50",
+                                              "value": 50,
+                                            },
+                                          ]
+                                        }
+                                        selectOption={[Function]}
+                                        selectProps={
+                                          Object {
+                                            "backspaceRemovesValue": true,
+                                            "blurInputOnSelect": true,
+                                            "borderless": true,
+                                            "captureMenuScroll": false,
+                                            "closeMenuOnScroll": false,
+                                            "closeMenuOnSelect": true,
+                                            "components": Object {
+                                              "Option": [Function],
+                                            },
+                                            "controlShouldRenderValue": true,
+                                            "escapeClearsValue": false,
+                                            "filterOption": [Function],
+                                            "formatGroupLabel": [Function],
+                                            "getOptionLabel": [Function],
+                                            "getOptionValue": [Function],
+                                            "icon": undefined,
+                                            "inputValue": "",
+                                            "isDisabled": false,
+                                            "isLoading": false,
+                                            "isMulti": false,
+                                            "isOptionDisabled": [Function],
+                                            "isRtl": false,
+                                            "isSearchable": true,
+                                            "loadingMessage": [Function],
+                                            "maxMenuHeight": 300,
+                                            "menuIsOpen": false,
+                                            "menuPlacement": "auto",
+                                            "menuPosition": "absolute",
+                                            "menuShouldBlockScroll": false,
+                                            "menuShouldScrollIntoView": true,
+                                            "minMenuHeight": 140,
+                                            "noOptionsMessage": [Function],
+                                            "onChange": [Function],
+                                            "onInputChange": [Function],
+                                            "onMenuClose": [Function],
+                                            "onMenuOpen": [Function],
+                                            "openMenuOnClick": true,
+                                            "openMenuOnFocus": false,
+                                            "options": Array [
+                                              Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                              Object {
+                                                "label": "20",
+                                                "value": 20,
+                                              },
+                                              Object {
+                                                "label": "50",
+                                                "value": 50,
+                                              },
+                                            ],
+                                            "pageSize": 5,
+                                            "placeholder": "Select...",
+                                            "screenReaderStatus": [Function],
+                                            "styles": Object {
+                                              "clearIndicator": [Function],
+                                              "container": [Function],
+                                              "control": [Function],
+                                              "dropdownIndicator": [Function],
+                                              "indicatorSeparator": [Function],
+                                              "indicatorsContainer": [Function],
+                                              "menu": [Function],
+                                              "menuList": [Function],
+                                              "menuPortal": [Function],
+                                              "option": [Function],
+                                              "singleValue": [Function],
+                                              "valueContainer": [Function],
+                                            },
+                                            "tabIndex": "0",
+                                            "tabSelectsValue": true,
+                                            "value": Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                          }
+                                        }
+                                        setValue={[Function]}
+                                        theme={
+                                          Object {
+                                            "borderRadius": 4,
+                                            "colors": Object {
+                                              "danger": "#DE350B",
+                                              "dangerLight": "#FFBDAD",
+                                              "neutral0": "hsl(0, 0%, 100%)",
+                                              "neutral10": "hsl(0, 0%, 90%)",
+                                              "neutral20": "hsl(0, 0%, 80%)",
+                                              "neutral30": "hsl(0, 0%, 70%)",
+                                              "neutral40": "hsl(0, 0%, 60%)",
+                                              "neutral5": "hsl(0, 0%, 95%)",
+                                              "neutral50": "hsl(0, 0%, 50%)",
+                                              "neutral60": "hsl(0, 0%, 40%)",
+                                              "neutral70": "hsl(0, 0%, 30%)",
+                                              "neutral80": "hsl(0, 0%, 20%)",
+                                              "neutral90": "hsl(0, 0%, 10%)",
+                                              "primary": "#2684FF",
+                                              "primary25": "#DEEBFF",
+                                              "primary50": "#B2D4FF",
+                                              "primary75": "#4C9AFF",
+                                            },
+                                            "spacing": Object {
+                                              "baseUnit": 4,
+                                              "controlHeight": 38,
+                                              "menuGutter": 8,
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <EmotionCssPropInternal
+                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                          className=""
+                                          css={
+                                            Object {
+                                              "WebkitOverflowScrolling": "touch",
+                                              "alignItems": "center",
+                                              "boxSizing": "border-box",
+                                              "display": "flex",
+                                              "flex": 1,
+                                              "flexWrap": "wrap",
+                                              "overflow": "hidden",
+                                              "padding": "0 10px",
+                                              "position": "relative",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=" css-1gbz4ua"
+                                          >
+                                            <SingleValue
+                                              clearValue={[Function]}
+                                              cx={[Function]}
+                                              data={
+                                                Object {
+                                                  "label": "5",
+                                                  "value": 5,
+                                                }
+                                              }
+                                              getStyles={[Function]}
+                                              getValue={[Function]}
+                                              hasValue={true}
+                                              isDisabled={false}
+                                              isMulti={false}
+                                              isRtl={false}
+                                              options={
+                                                Array [
+                                                  Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                  Object {
+                                                    "label": "20",
+                                                    "value": 20,
+                                                  },
+                                                  Object {
+                                                    "label": "50",
+                                                    "value": 50,
+                                                  },
+                                                ]
+                                              }
+                                              selectOption={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              setValue={[Function]}
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SingleValue"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                className=""
+                                                css={
+                                                  Object {
+                                                    "boxSizing": "border-box",
+                                                    "color": "inherit",
+                                                    "label": "singleValue",
+                                                    "marginLeft": 2,
+                                                    "marginRight": 2,
+                                                    "maxWidth": "calc(100% - 8px)",
+                                                    "overflow": "hidden",
+                                                    "position": "absolute",
+                                                    "textOverflow": "ellipsis",
+                                                    "top": "50%",
+                                                    "transform": "translateY(-50%)",
+                                                    "whiteSpace": "nowrap",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className=" css-1xqm9c7-singleValue"
+                                                >
+                                                  5
+                                                </div>
+                                              </EmotionCssPropInternal>
+                                            </SingleValue>
+                                            <Input
+                                              aria-autocomplete="list"
+                                              autoCapitalize="none"
+                                              autoComplete="off"
+                                              autoCorrect="off"
+                                              cx={[Function]}
+                                              getStyles={[Function]}
+                                              id="react-select-2-input"
+                                              innerRef={[Function]}
+                                              isDisabled={false}
+                                              isHidden={false}
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              spellCheck="false"
+                                              tabIndex="0"
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                              type="text"
+                                              value=""
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                css={
+                                                  Object {
+                                                    "boxSizing": "border-box",
+                                                    "color": "hsl(0, 0%, 20%)",
+                                                    "margin": 2,
+                                                    "paddingBottom": 2,
+                                                    "paddingTop": 2,
+                                                    "visibility": "visible",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className="css-b8ldur-Input"
+                                                >
+                                                  <AutosizeInput
+                                                    aria-autocomplete="list"
+                                                    autoCapitalize="none"
+                                                    autoComplete="off"
+                                                    autoCorrect="off"
+                                                    className=""
+                                                    disabled={false}
+                                                    id="react-select-2-input"
+                                                    injectStyles={true}
+                                                    inputRef={[Function]}
+                                                    inputStyle={
+                                                      Object {
+                                                        "background": 0,
+                                                        "border": 0,
+                                                        "color": "inherit",
+                                                        "fontSize": "inherit",
+                                                        "label": "input",
+                                                        "opacity": 1,
+                                                        "outline": 0,
+                                                        "padding": 0,
+                                                      }
+                                                    }
+                                                    minWidth={1}
+                                                    onBlur={[Function]}
+                                                    onChange={[Function]}
+                                                    onFocus={[Function]}
+                                                    spellCheck="false"
+                                                    tabIndex="0"
+                                                    type="text"
+                                                    value=""
+                                                  >
+                                                    <div
+                                                      className=""
+                                                      style={
+                                                        Object {
+                                                          "display": "inline-block",
+                                                        }
+                                                      }
+                                                    >
+                                                      <input
+                                                        aria-autocomplete="list"
+                                                        autoCapitalize="none"
+                                                        autoComplete="off"
+                                                        autoCorrect="off"
+                                                        disabled={false}
+                                                        id="react-select-2-input"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onFocus={[Function]}
+                                                        spellCheck="false"
+                                                        style={
+                                                          Object {
+                                                            "background": 0,
+                                                            "border": 0,
+                                                            "boxSizing": "content-box",
+                                                            "color": "inherit",
+                                                            "fontSize": "inherit",
+                                                            "label": "input",
+                                                            "opacity": 1,
+                                                            "outline": 0,
+                                                            "padding": 0,
+                                                            "width": "2px",
+                                                          }
+                                                        }
+                                                        tabIndex="0"
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                      <div
+                                                        style={
+                                                          Object {
+                                                            "height": 0,
+                                                            "left": 0,
+                                                            "overflow": "scroll",
+                                                            "position": "absolute",
+                                                            "top": 0,
+                                                            "visibility": "hidden",
+                                                            "whiteSpace": "pre",
+                                                          }
+                                                        }
+                                                      />
+                                                    </div>
+                                                  </AutosizeInput>
+                                                </div>
+                                              </EmotionCssPropInternal>
+                                            </Input>
+                                          </div>
+                                        </EmotionCssPropInternal>
+                                      </ValueContainer>
+                                      <IndicatorsContainer
+                                        clearValue={[Function]}
+                                        cx={[Function]}
+                                        getStyles={[Function]}
+                                        getValue={[Function]}
+                                        hasValue={true}
+                                        isDisabled={false}
+                                        isMulti={false}
+                                        isRtl={false}
+                                        options={
+                                          Array [
+                                            Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                            Object {
+                                              "label": "20",
+                                              "value": 20,
+                                            },
+                                            Object {
+                                              "label": "50",
+                                              "value": 50,
+                                            },
+                                          ]
+                                        }
+                                        selectOption={[Function]}
+                                        selectProps={
+                                          Object {
+                                            "backspaceRemovesValue": true,
+                                            "blurInputOnSelect": true,
+                                            "borderless": true,
+                                            "captureMenuScroll": false,
+                                            "closeMenuOnScroll": false,
+                                            "closeMenuOnSelect": true,
+                                            "components": Object {
+                                              "Option": [Function],
+                                            },
+                                            "controlShouldRenderValue": true,
+                                            "escapeClearsValue": false,
+                                            "filterOption": [Function],
+                                            "formatGroupLabel": [Function],
+                                            "getOptionLabel": [Function],
+                                            "getOptionValue": [Function],
+                                            "icon": undefined,
+                                            "inputValue": "",
+                                            "isDisabled": false,
+                                            "isLoading": false,
+                                            "isMulti": false,
+                                            "isOptionDisabled": [Function],
+                                            "isRtl": false,
+                                            "isSearchable": true,
+                                            "loadingMessage": [Function],
+                                            "maxMenuHeight": 300,
+                                            "menuIsOpen": false,
+                                            "menuPlacement": "auto",
+                                            "menuPosition": "absolute",
+                                            "menuShouldBlockScroll": false,
+                                            "menuShouldScrollIntoView": true,
+                                            "minMenuHeight": 140,
+                                            "noOptionsMessage": [Function],
+                                            "onChange": [Function],
+                                            "onInputChange": [Function],
+                                            "onMenuClose": [Function],
+                                            "onMenuOpen": [Function],
+                                            "openMenuOnClick": true,
+                                            "openMenuOnFocus": false,
+                                            "options": Array [
+                                              Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                              Object {
+                                                "label": "20",
+                                                "value": 20,
+                                              },
+                                              Object {
+                                                "label": "50",
+                                                "value": 50,
+                                              },
+                                            ],
+                                            "pageSize": 5,
+                                            "placeholder": "Select...",
+                                            "screenReaderStatus": [Function],
+                                            "styles": Object {
+                                              "clearIndicator": [Function],
+                                              "container": [Function],
+                                              "control": [Function],
+                                              "dropdownIndicator": [Function],
+                                              "indicatorSeparator": [Function],
+                                              "indicatorsContainer": [Function],
+                                              "menu": [Function],
+                                              "menuList": [Function],
+                                              "menuPortal": [Function],
+                                              "option": [Function],
+                                              "singleValue": [Function],
+                                              "valueContainer": [Function],
+                                            },
+                                            "tabIndex": "0",
+                                            "tabSelectsValue": true,
+                                            "value": Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                          }
+                                        }
+                                        setValue={[Function]}
+                                        theme={
+                                          Object {
+                                            "borderRadius": 4,
+                                            "colors": Object {
+                                              "danger": "#DE350B",
+                                              "dangerLight": "#FFBDAD",
+                                              "neutral0": "hsl(0, 0%, 100%)",
+                                              "neutral10": "hsl(0, 0%, 90%)",
+                                              "neutral20": "hsl(0, 0%, 80%)",
+                                              "neutral30": "hsl(0, 0%, 70%)",
+                                              "neutral40": "hsl(0, 0%, 60%)",
+                                              "neutral5": "hsl(0, 0%, 95%)",
+                                              "neutral50": "hsl(0, 0%, 50%)",
+                                              "neutral60": "hsl(0, 0%, 40%)",
+                                              "neutral70": "hsl(0, 0%, 30%)",
+                                              "neutral80": "hsl(0, 0%, 20%)",
+                                              "neutral90": "hsl(0, 0%, 10%)",
+                                              "primary": "#2684FF",
+                                              "primary25": "#DEEBFF",
+                                              "primary50": "#B2D4FF",
+                                              "primary75": "#4C9AFF",
+                                            },
+                                            "spacing": Object {
+                                              "baseUnit": 4,
+                                              "controlHeight": 38,
+                                              "menuGutter": 8,
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <EmotionCssPropInternal
+                                          __EMOTION_LABEL_PLEASE_DO_NOT_USE__="IndicatorsContainer"
+                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                          className=""
+                                          css={
+                                            Object {
+                                              "alignItems": "center",
+                                              "alignSelf": "stretch",
+                                              "boxSizing": "border-box",
+                                              "color": "#b6bbc7",
+                                              "display": "flex",
+                                              "flexShrink": 0,
+                                              "marginRight": "5px",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=" css-1y4h2k2-IndicatorsContainer"
+                                          >
+                                            <IndicatorSeparator
+                                              clearValue={[Function]}
+                                              cx={[Function]}
+                                              getStyles={[Function]}
+                                              getValue={[Function]}
+                                              hasValue={true}
+                                              isDisabled={false}
+                                              isFocused={false}
+                                              isMulti={false}
+                                              isRtl={false}
+                                              options={
+                                                Array [
+                                                  Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                  Object {
+                                                    "label": "20",
+                                                    "value": 20,
+                                                  },
+                                                  Object {
+                                                    "label": "50",
+                                                    "value": 50,
+                                                  },
+                                                ]
+                                              }
+                                              selectOption={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              setValue={[Function]}
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="IndicatorSeparator"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="span"
+                                                className=""
+                                                css={
+                                                  Object {
+                                                    "display": "none",
+                                                  }
+                                                }
+                                              >
+                                                <span
+                                                  className=" css-1xjgjl1-IndicatorSeparator"
+                                                />
+                                              </EmotionCssPropInternal>
+                                            </IndicatorSeparator>
+                                            <DropdownIndicator
+                                              clearValue={[Function]}
+                                              cx={[Function]}
+                                              getStyles={[Function]}
+                                              getValue={[Function]}
+                                              hasValue={true}
+                                              innerProps={
+                                                Object {
+                                                  "aria-hidden": "true",
+                                                  "onMouseDown": [Function],
+                                                  "onTouchEnd": [Function],
+                                                }
+                                              }
+                                              isDisabled={false}
+                                              isFocused={false}
+                                              isMulti={false}
+                                              isRtl={false}
+                                              options={
+                                                Array [
+                                                  Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                  Object {
+                                                    "label": "20",
+                                                    "value": 20,
+                                                  },
+                                                  Object {
+                                                    "label": "50",
+                                                    "value": 50,
+                                                  },
+                                                ]
+                                              }
+                                              selectOption={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              setValue={[Function]}
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                aria-hidden="true"
+                                                className=""
+                                                css={
+                                                  Object {
+                                                    "color": "#b6bbc7",
+                                                    "display": "flex",
+                                                    "margin": "5px",
+                                                    "padding": "0",
+                                                  }
+                                                }
+                                                onMouseDown={[Function]}
+                                                onTouchEnd={[Function]}
+                                              >
+                                                <div
+                                                  aria-hidden="true"
+                                                  className=" css-1vd5qh6-DropdownIndicator"
+                                                  onMouseDown={[Function]}
+                                                  onTouchEnd={[Function]}
+                                                >
+                                                  <DownChevron>
+                                                    <Svg
+                                                      size={20}
+                                                    >
+                                                      <EmotionCssPropInternal
+                                                        __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
+                                                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
+                                                        aria-hidden="true"
+                                                        css={
+                                                          Object {
+                                                            "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
+                                                            "name": "19bqh2r",
+                                                            "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
+                                                          }
+                                                        }
+                                                        focusable="false"
+                                                        height={20}
+                                                        viewBox="0 0 20 20"
+                                                        width={20}
+                                                      >
+                                                        <svg
+                                                          aria-hidden="true"
+                                                          className="css-6q0nyr-Svg"
+                                                          focusable="false"
+                                                          height={20}
+                                                          viewBox="0 0 20 20"
+                                                          width={20}
+                                                        >
+                                                          <path
+                                                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                                          />
+                                                        </svg>
+                                                      </EmotionCssPropInternal>
+                                                    </Svg>
+                                                  </DownChevron>
+                                                </div>
+                                              </EmotionCssPropInternal>
+                                            </DropdownIndicator>
+                                          </div>
+                                        </EmotionCssPropInternal>
+                                      </IndicatorsContainer>
+                                    </div>
+                                  </EmotionCssPropInternal>
+                                </Control>
+                              </div>
+                            </EmotionCssPropInternal>
+                          </SelectContainer>
+                        </Select>
+                      </StateManager>
+                    </SelectController>
+                  </Select>
+                </div>
+              </StyledComponent>
+            </styled__RowPerPageWrapper>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 5 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c3",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c3"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c4",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c4"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c5",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c5"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={false}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={false}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={false}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={false}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c3",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c3"
+                      disabled={false}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c4",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c4"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c5",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c5"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+    <styled__StyledTable>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "styled__StyledTable-r3xwjs-0",
+              "isStatic": false,
+              "lastClassName": "c6",
+              "rules": Array [
+                "background-color:",
+                "#ffffff",
+                ";border-collapse:collapse;border:none;table-layout:fixed;width:100%;",
+              ],
             },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
+            "displayName": "styled__StyledTable",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "styled__StyledTable-r3xwjs-0",
+            "target": "table",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
         }
+        forwardedRef={null}
+      >
+        <table
+          className="c6"
+        >
+          <TableHeader
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c12",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            onSort={[Function]}
+            order={false}
+            sticky={true}
+          >
+            <thead>
+              <styled__StyledRow
+                sticky={true}
+              >
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__StyledRow-r3xwjs-3",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          "background-color:",
+                          "#ffffff",
+                          ";border-bottom:1px solid ",
+                          "#dcdce7",
+                          ";td,th{",
+                          [Function],
+                          "};",
+                        ],
+                      },
+                      "displayName": "styled__StyledRow",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                      "target": "tr",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  sticky={true}
+                >
+                  <tr
+                    className="c7"
+                  >
+                    <HeadCell
+                      cellStyle={
+                        Object {
+                          "width": "33%",
+                        }
+                      }
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c12",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="name"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={
+                          Object {
+                            "width": "33%",
+                          }
+                        }
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={
+                            Object {
+                              "width": "33%",
+                            }
+                          }
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Subject Name
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c12",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="dob"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c9"
+                            onClick={[Function]}
+                          >
+                            Date of Birth
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c12",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="manager"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c9"
+                            onClick={[Function]}
+                          >
+                            Manager
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c12",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="lastUpdated"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c9"
+                            onClick={[Function]}
+                          >
+                            Last Updated
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c12",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="id"
+                      order={false}
+                      sortable={false}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <th
+                            className="c10"
+                          >
+                            ID
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                  </tr>
+                </StyledComponent>
+              </styled__StyledRow>
+            </thead>
+          </TableHeader>
+          <TableBody
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c12",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            data={
+              Array [
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "1",
+                  "lastUpdated": "2019-09-01",
+                  "manager": "Spongebob",
+                  "name": "Eugene Krabs",
+                },
+                Object {
+                  "dob": "",
+                  "id": "2",
+                  "lastUpdated": "2019-08-29",
+                  "manager": "Smitty",
+                  "name": "Squidward Tentacles",
+                },
+                Object {
+                  "dob": "1987-11-17",
+                  "id": "3",
+                  "lastUpdated": "2019-07-30",
+                  "manager": "Patrick",
+                  "name": "Sandy Cheeks",
+                },
+                Object {
+                  "dob": "1975-06-23",
+                  "id": "4",
+                  "lastUpdated": "2019-08-16",
+                  "manager": "Patchy",
+                  "name": "Larry the Lobster",
+                },
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "5",
+                  "lastUpdated": "2019-08-20",
+                  "manager": "Spongebob",
+                  "name": "Sheldon Plankton",
+                },
+                Object {
+                  "dob": "",
+                  "id": "6",
+                  "lastUpdated": "2019-08-21",
+                  "manager": "Spongebob",
+                  "name": "Mrs. Puff",
+                },
+                Object {
+                  "dob": "1678-04-20",
+                  "id": "7",
+                  "lastUpdated": "2019-06-21",
+                  "manager": "Spongebob",
+                  "name": "Flying Dutchman",
+                },
+              ]
+            }
+            exact={false}
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            page={0}
+            rowsPerPage={5}
+          >
+            <tbody>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c12",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "1",
+                    "lastUpdated": "2019-09-01",
+                    "manager": "Spongebob",
+                    "name": "Eugene Krabs",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="1"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c11",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c11"
+                    >
+                      <Cell
+                        key="1_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Eugene Krabs
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            2019-09-01
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            1
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c12",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "2",
+                    "lastUpdated": "2019-08-29",
+                    "manager": "Smitty",
+                    "name": "Squidward Tentacles",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="2"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c11",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c11"
+                    >
+                      <Cell
+                        key="2_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Squidward Tentacles
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Smitty
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            2019-08-29
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            2
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c12",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1987-11-17",
+                    "id": "3",
+                    "lastUpdated": "2019-07-30",
+                    "manager": "Patrick",
+                    "name": "Sandy Cheeks",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="3"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c11",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c11"
+                    >
+                      <Cell
+                        key="3_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Sandy Cheeks
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            1987-11-17
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Patrick
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            2019-07-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            3
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c12",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1975-06-23",
+                    "id": "4",
+                    "lastUpdated": "2019-08-16",
+                    "manager": "Patchy",
+                    "name": "Larry the Lobster",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="4"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c11",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c11"
+                    >
+                      <Cell
+                        key="4_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Larry the Lobster
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            1975-06-23
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Patchy
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            2019-08-16
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            4
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c12",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "5",
+                    "lastUpdated": "2019-08-20",
+                    "manager": "Spongebob",
+                    "name": "Sheldon Plankton",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="5"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c11",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c11"
+                    >
+                      <Cell
+                        key="5_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Sheldon Plankton
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            2019-08-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c12",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c12"
+                          >
+                            5
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+            </tbody>
+          </TableBody>
+        </table>
+      </StyledComponent>
+    </styled__StyledTable>
+    <PaginationToolbar
+      count={7}
+      onPageChange={[Function]}
+      page={0}
+      rowsPerPage={5}
+      rowsPerPageOptions={
+        Array [
+          5,
+          20,
+          50,
+        ]
       }
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <styled__RowPerPageWrapper>
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "styled__RowPerPageWrapper-r3xwjs-4",
+                      "isStatic": false,
+                      "lastClassName": "c2",
+                      "rules": Array [
+                        "font-size:14px;margin-right:10px;width:75px;",
+                      ],
+                    },
+                    "displayName": "styled__RowPerPageWrapper",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "styled__RowPerPageWrapper-r3xwjs-4",
+                    "target": "div",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+              >
+                <div
+                  className="c2"
+                >
+                  <Select
+                    borderless={true}
+                    defaultValue={
+                      Object {
+                        "label": "5",
+                        "value": 5,
+                      }
+                    }
+                    onChange={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "label": "5",
+                          "value": 5,
+                        },
+                        Object {
+                          "label": "20",
+                          "value": 20,
+                        },
+                        Object {
+                          "label": "50",
+                          "value": 50,
+                        },
+                      ]
+                    }
+                    useRawValues={true}
+                    value={5}
+                  >
+                    <SelectController
+                      borderless={true}
+                      defaultValue={
+                        Object {
+                          "label": "5",
+                          "value": 5,
+                        }
+                      }
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "label": "5",
+                            "value": 5,
+                          },
+                          Object {
+                            "label": "20",
+                            "value": 20,
+                          },
+                          Object {
+                            "label": "50",
+                            "value": 50,
+                          },
+                        ]
+                      }
+                      render={[Function]}
+                      useRawValues={true}
+                      value={5}
+                    >
+                      <StateManager
+                        borderless={true}
+                        components={
+                          Object {
+                            "Option": [Function],
+                          }
+                        }
+                        defaultInputValue=""
+                        defaultMenuIsOpen={false}
+                        defaultValue={
+                          Object {
+                            "label": "5",
+                            "value": 5,
+                          }
+                        }
+                        filterOption={[Function]}
+                        menuPlacement="auto"
+                        onChange={[Function]}
+                        options={
+                          Array [
+                            Object {
+                              "label": "5",
+                              "value": 5,
+                            },
+                            Object {
+                              "label": "20",
+                              "value": 20,
+                            },
+                            Object {
+                              "label": "50",
+                              "value": 50,
+                            },
+                          ]
+                        }
+                        styles={
+                          Object {
+                            "clearIndicator": [Function],
+                            "container": [Function],
+                            "control": [Function],
+                            "dropdownIndicator": [Function],
+                            "indicatorSeparator": [Function],
+                            "indicatorsContainer": [Function],
+                            "menu": [Function],
+                            "menuList": [Function],
+                            "menuPortal": [Function],
+                            "option": [Function],
+                            "singleValue": [Function],
+                            "valueContainer": [Function],
+                          }
+                        }
+                        value={
+                          Object {
+                            "label": "5",
+                            "value": 5,
+                          }
+                        }
+                      >
+                        <Select
+                          backspaceRemovesValue={true}
+                          blurInputOnSelect={true}
+                          borderless={true}
+                          captureMenuScroll={false}
+                          closeMenuOnScroll={false}
+                          closeMenuOnSelect={true}
+                          components={
+                            Object {
+                              "Option": [Function],
+                            }
+                          }
+                          controlShouldRenderValue={true}
+                          escapeClearsValue={false}
+                          filterOption={[Function]}
+                          formatGroupLabel={[Function]}
+                          getOptionLabel={[Function]}
+                          getOptionValue={[Function]}
+                          inputValue=""
+                          isDisabled={false}
+                          isLoading={false}
+                          isMulti={false}
+                          isOptionDisabled={[Function]}
+                          isRtl={false}
+                          isSearchable={true}
+                          loadingMessage={[Function]}
+                          maxMenuHeight={300}
+                          menuIsOpen={false}
+                          menuPlacement="auto"
+                          menuPosition="absolute"
+                          menuShouldBlockScroll={false}
+                          menuShouldScrollIntoView={true}
+                          minMenuHeight={140}
+                          noOptionsMessage={[Function]}
+                          onChange={[Function]}
+                          onInputChange={[Function]}
+                          onMenuClose={[Function]}
+                          onMenuOpen={[Function]}
+                          openMenuOnClick={true}
+                          openMenuOnFocus={false}
+                          options={
+                            Array [
+                              Object {
+                                "label": "5",
+                                "value": 5,
+                              },
+                              Object {
+                                "label": "20",
+                                "value": 20,
+                              },
+                              Object {
+                                "label": "50",
+                                "value": 50,
+                              },
+                            ]
+                          }
+                          pageSize={5}
+                          placeholder="Select..."
+                          screenReaderStatus={[Function]}
+                          styles={
+                            Object {
+                              "clearIndicator": [Function],
+                              "container": [Function],
+                              "control": [Function],
+                              "dropdownIndicator": [Function],
+                              "indicatorSeparator": [Function],
+                              "indicatorsContainer": [Function],
+                              "menu": [Function],
+                              "menuList": [Function],
+                              "menuPortal": [Function],
+                              "option": [Function],
+                              "singleValue": [Function],
+                              "valueContainer": [Function],
+                            }
+                          }
+                          tabIndex="0"
+                          tabSelectsValue={true}
+                          value={
+                            Object {
+                              "label": "5",
+                              "value": 5,
+                            }
+                          }
+                        >
+                          <SelectContainer
+                            clearValue={[Function]}
+                            cx={[Function]}
+                            getStyles={[Function]}
+                            getValue={[Function]}
+                            hasValue={true}
+                            innerProps={
+                              Object {
+                                "id": undefined,
+                                "onKeyDown": [Function],
+                              }
+                            }
+                            isDisabled={false}
+                            isFocused={false}
+                            isMulti={false}
+                            isRtl={false}
+                            options={
+                              Array [
+                                Object {
+                                  "label": "5",
+                                  "value": 5,
+                                },
+                                Object {
+                                  "label": "20",
+                                  "value": 20,
+                                },
+                                Object {
+                                  "label": "50",
+                                  "value": 50,
+                                },
+                              ]
+                            }
+                            selectOption={[Function]}
+                            selectProps={
+                              Object {
+                                "backspaceRemovesValue": true,
+                                "blurInputOnSelect": true,
+                                "borderless": true,
+                                "captureMenuScroll": false,
+                                "closeMenuOnScroll": false,
+                                "closeMenuOnSelect": true,
+                                "components": Object {
+                                  "Option": [Function],
+                                },
+                                "controlShouldRenderValue": true,
+                                "escapeClearsValue": false,
+                                "filterOption": [Function],
+                                "formatGroupLabel": [Function],
+                                "getOptionLabel": [Function],
+                                "getOptionValue": [Function],
+                                "icon": undefined,
+                                "inputValue": "",
+                                "isDisabled": false,
+                                "isLoading": false,
+                                "isMulti": false,
+                                "isOptionDisabled": [Function],
+                                "isRtl": false,
+                                "isSearchable": true,
+                                "loadingMessage": [Function],
+                                "maxMenuHeight": 300,
+                                "menuIsOpen": false,
+                                "menuPlacement": "auto",
+                                "menuPosition": "absolute",
+                                "menuShouldBlockScroll": false,
+                                "menuShouldScrollIntoView": true,
+                                "minMenuHeight": 140,
+                                "noOptionsMessage": [Function],
+                                "onChange": [Function],
+                                "onInputChange": [Function],
+                                "onMenuClose": [Function],
+                                "onMenuOpen": [Function],
+                                "openMenuOnClick": true,
+                                "openMenuOnFocus": false,
+                                "options": Array [
+                                  Object {
+                                    "label": "5",
+                                    "value": 5,
+                                  },
+                                  Object {
+                                    "label": "20",
+                                    "value": 20,
+                                  },
+                                  Object {
+                                    "label": "50",
+                                    "value": 50,
+                                  },
+                                ],
+                                "pageSize": 5,
+                                "placeholder": "Select...",
+                                "screenReaderStatus": [Function],
+                                "styles": Object {
+                                  "clearIndicator": [Function],
+                                  "container": [Function],
+                                  "control": [Function],
+                                  "dropdownIndicator": [Function],
+                                  "indicatorSeparator": [Function],
+                                  "indicatorsContainer": [Function],
+                                  "menu": [Function],
+                                  "menuList": [Function],
+                                  "menuPortal": [Function],
+                                  "option": [Function],
+                                  "singleValue": [Function],
+                                  "valueContainer": [Function],
+                                },
+                                "tabIndex": "0",
+                                "tabSelectsValue": true,
+                                "value": Object {
+                                  "label": "5",
+                                  "value": 5,
+                                },
+                              }
+                            }
+                            setValue={[Function]}
+                            theme={
+                              Object {
+                                "borderRadius": 4,
+                                "colors": Object {
+                                  "danger": "#DE350B",
+                                  "dangerLight": "#FFBDAD",
+                                  "neutral0": "hsl(0, 0%, 100%)",
+                                  "neutral10": "hsl(0, 0%, 90%)",
+                                  "neutral20": "hsl(0, 0%, 80%)",
+                                  "neutral30": "hsl(0, 0%, 70%)",
+                                  "neutral40": "hsl(0, 0%, 60%)",
+                                  "neutral5": "hsl(0, 0%, 95%)",
+                                  "neutral50": "hsl(0, 0%, 50%)",
+                                  "neutral60": "hsl(0, 0%, 40%)",
+                                  "neutral70": "hsl(0, 0%, 30%)",
+                                  "neutral80": "hsl(0, 0%, 20%)",
+                                  "neutral90": "hsl(0, 0%, 10%)",
+                                  "primary": "#2684FF",
+                                  "primary25": "#DEEBFF",
+                                  "primary50": "#B2D4FF",
+                                  "primary75": "#4C9AFF",
+                                },
+                                "spacing": Object {
+                                  "baseUnit": 4,
+                                  "controlHeight": 38,
+                                  "menuGutter": 8,
+                                },
+                              }
+                            }
+                          >
+                            <EmotionCssPropInternal
+                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SelectContainer"
+                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                              className=""
+                              css={
+                                Object {
+                                  "boxSizing": "border-box",
+                                  "cursor": "default",
+                                  "direction": null,
+                                  "label": "container",
+                                  "pointerEvents": "auto",
+                                  "position": "relative",
+                                  "width": "100%",
+                                }
+                              }
+                              onKeyDown={[Function]}
+                            >
+                              <div
+                                className=" css-gprrux-container"
+                                onKeyDown={[Function]}
+                              >
+                                <Control
+                                  clearValue={[Function]}
+                                  cx={[Function]}
+                                  getStyles={[Function]}
+                                  getValue={[Function]}
+                                  hasValue={true}
+                                  innerProps={
+                                    Object {
+                                      "onMouseDown": [Function],
+                                      "onTouchEnd": [Function],
+                                    }
+                                  }
+                                  innerRef={[Function]}
+                                  isDisabled={false}
+                                  isFocused={false}
+                                  isMulti={false}
+                                  isRtl={false}
+                                  menuIsOpen={false}
+                                  options={
+                                    Array [
+                                      Object {
+                                        "label": "5",
+                                        "value": 5,
+                                      },
+                                      Object {
+                                        "label": "20",
+                                        "value": 20,
+                                      },
+                                      Object {
+                                        "label": "50",
+                                        "value": 50,
+                                      },
+                                    ]
+                                  }
+                                  selectOption={[Function]}
+                                  selectProps={
+                                    Object {
+                                      "backspaceRemovesValue": true,
+                                      "blurInputOnSelect": true,
+                                      "borderless": true,
+                                      "captureMenuScroll": false,
+                                      "closeMenuOnScroll": false,
+                                      "closeMenuOnSelect": true,
+                                      "components": Object {
+                                        "Option": [Function],
+                                      },
+                                      "controlShouldRenderValue": true,
+                                      "escapeClearsValue": false,
+                                      "filterOption": [Function],
+                                      "formatGroupLabel": [Function],
+                                      "getOptionLabel": [Function],
+                                      "getOptionValue": [Function],
+                                      "icon": undefined,
+                                      "inputValue": "",
+                                      "isDisabled": false,
+                                      "isLoading": false,
+                                      "isMulti": false,
+                                      "isOptionDisabled": [Function],
+                                      "isRtl": false,
+                                      "isSearchable": true,
+                                      "loadingMessage": [Function],
+                                      "maxMenuHeight": 300,
+                                      "menuIsOpen": false,
+                                      "menuPlacement": "auto",
+                                      "menuPosition": "absolute",
+                                      "menuShouldBlockScroll": false,
+                                      "menuShouldScrollIntoView": true,
+                                      "minMenuHeight": 140,
+                                      "noOptionsMessage": [Function],
+                                      "onChange": [Function],
+                                      "onInputChange": [Function],
+                                      "onMenuClose": [Function],
+                                      "onMenuOpen": [Function],
+                                      "openMenuOnClick": true,
+                                      "openMenuOnFocus": false,
+                                      "options": Array [
+                                        Object {
+                                          "label": "5",
+                                          "value": 5,
+                                        },
+                                        Object {
+                                          "label": "20",
+                                          "value": 20,
+                                        },
+                                        Object {
+                                          "label": "50",
+                                          "value": 50,
+                                        },
+                                      ],
+                                      "pageSize": 5,
+                                      "placeholder": "Select...",
+                                      "screenReaderStatus": [Function],
+                                      "styles": Object {
+                                        "clearIndicator": [Function],
+                                        "container": [Function],
+                                        "control": [Function],
+                                        "dropdownIndicator": [Function],
+                                        "indicatorSeparator": [Function],
+                                        "indicatorsContainer": [Function],
+                                        "menu": [Function],
+                                        "menuList": [Function],
+                                        "menuPortal": [Function],
+                                        "option": [Function],
+                                        "singleValue": [Function],
+                                        "valueContainer": [Function],
+                                      },
+                                      "tabIndex": "0",
+                                      "tabSelectsValue": true,
+                                      "value": Object {
+                                        "label": "5",
+                                        "value": 5,
+                                      },
+                                    }
+                                  }
+                                  setValue={[Function]}
+                                  theme={
+                                    Object {
+                                      "borderRadius": 4,
+                                      "colors": Object {
+                                        "danger": "#DE350B",
+                                        "dangerLight": "#FFBDAD",
+                                        "neutral0": "hsl(0, 0%, 100%)",
+                                        "neutral10": "hsl(0, 0%, 90%)",
+                                        "neutral20": "hsl(0, 0%, 80%)",
+                                        "neutral30": "hsl(0, 0%, 70%)",
+                                        "neutral40": "hsl(0, 0%, 60%)",
+                                        "neutral5": "hsl(0, 0%, 95%)",
+                                        "neutral50": "hsl(0, 0%, 50%)",
+                                        "neutral60": "hsl(0, 0%, 40%)",
+                                        "neutral70": "hsl(0, 0%, 30%)",
+                                        "neutral80": "hsl(0, 0%, 20%)",
+                                        "neutral90": "hsl(0, 0%, 10%)",
+                                        "primary": "#2684FF",
+                                        "primary25": "#DEEBFF",
+                                        "primary50": "#B2D4FF",
+                                        "primary75": "#4C9AFF",
+                                      },
+                                      "spacing": Object {
+                                        "baseUnit": 4,
+                                        "controlHeight": 38,
+                                        "menuGutter": 8,
+                                      },
+                                    }
+                                  }
+                                >
+                                  <EmotionCssPropInternal
+                                    __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Control"
+                                    __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                    className=""
+                                    css={
+                                      Object {
+                                        "&:hover": Object {
+                                          "borderColor": "hsl(0, 0%, 70%)",
+                                        },
+                                        ":hover": Object {
+                                          "backgroundColor": "#f0f0f7",
+                                          "border": "none",
+                                        },
+                                        "alignItems": "center",
+                                        "backgroundColor": "transparent",
+                                        "border": "none",
+                                        "borderColor": "hsl(0, 0%, 80%)",
+                                        "borderRadius": "3px",
+                                        "borderStyle": "solid",
+                                        "borderWidth": 1,
+                                        "boxShadow": "none",
+                                        "boxSizing": "border-box",
+                                        "cursor": "default",
+                                        "display": "flex",
+                                        "flexWrap": "wrap",
+                                        "fontSize": "14px",
+                                        "justifyContent": "space-between",
+                                        "label": "control",
+                                        "lineHeight": 1.5,
+                                        "minHeight": "40px",
+                                        "outline": "0 !important",
+                                        "pointerEvents": "auto",
+                                        "position": "relative",
+                                        "transition": "background-color 0.2s ease-out, border-color 0.2s ease-out",
+                                      }
+                                    }
+                                    onMouseDown={[Function]}
+                                    onTouchEnd={[Function]}
+                                  >
+                                    <div
+                                      className=" css-1ugvnb2-control"
+                                      onMouseDown={[Function]}
+                                      onTouchEnd={[Function]}
+                                    >
+                                      <ValueContainer
+                                        clearValue={[Function]}
+                                        cx={[Function]}
+                                        getStyles={[Function]}
+                                        getValue={[Function]}
+                                        hasValue={true}
+                                        isDisabled={false}
+                                        isMulti={false}
+                                        isRtl={false}
+                                        options={
+                                          Array [
+                                            Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                            Object {
+                                              "label": "20",
+                                              "value": 20,
+                                            },
+                                            Object {
+                                              "label": "50",
+                                              "value": 50,
+                                            },
+                                          ]
+                                        }
+                                        selectOption={[Function]}
+                                        selectProps={
+                                          Object {
+                                            "backspaceRemovesValue": true,
+                                            "blurInputOnSelect": true,
+                                            "borderless": true,
+                                            "captureMenuScroll": false,
+                                            "closeMenuOnScroll": false,
+                                            "closeMenuOnSelect": true,
+                                            "components": Object {
+                                              "Option": [Function],
+                                            },
+                                            "controlShouldRenderValue": true,
+                                            "escapeClearsValue": false,
+                                            "filterOption": [Function],
+                                            "formatGroupLabel": [Function],
+                                            "getOptionLabel": [Function],
+                                            "getOptionValue": [Function],
+                                            "icon": undefined,
+                                            "inputValue": "",
+                                            "isDisabled": false,
+                                            "isLoading": false,
+                                            "isMulti": false,
+                                            "isOptionDisabled": [Function],
+                                            "isRtl": false,
+                                            "isSearchable": true,
+                                            "loadingMessage": [Function],
+                                            "maxMenuHeight": 300,
+                                            "menuIsOpen": false,
+                                            "menuPlacement": "auto",
+                                            "menuPosition": "absolute",
+                                            "menuShouldBlockScroll": false,
+                                            "menuShouldScrollIntoView": true,
+                                            "minMenuHeight": 140,
+                                            "noOptionsMessage": [Function],
+                                            "onChange": [Function],
+                                            "onInputChange": [Function],
+                                            "onMenuClose": [Function],
+                                            "onMenuOpen": [Function],
+                                            "openMenuOnClick": true,
+                                            "openMenuOnFocus": false,
+                                            "options": Array [
+                                              Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                              Object {
+                                                "label": "20",
+                                                "value": 20,
+                                              },
+                                              Object {
+                                                "label": "50",
+                                                "value": 50,
+                                              },
+                                            ],
+                                            "pageSize": 5,
+                                            "placeholder": "Select...",
+                                            "screenReaderStatus": [Function],
+                                            "styles": Object {
+                                              "clearIndicator": [Function],
+                                              "container": [Function],
+                                              "control": [Function],
+                                              "dropdownIndicator": [Function],
+                                              "indicatorSeparator": [Function],
+                                              "indicatorsContainer": [Function],
+                                              "menu": [Function],
+                                              "menuList": [Function],
+                                              "menuPortal": [Function],
+                                              "option": [Function],
+                                              "singleValue": [Function],
+                                              "valueContainer": [Function],
+                                            },
+                                            "tabIndex": "0",
+                                            "tabSelectsValue": true,
+                                            "value": Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                          }
+                                        }
+                                        setValue={[Function]}
+                                        theme={
+                                          Object {
+                                            "borderRadius": 4,
+                                            "colors": Object {
+                                              "danger": "#DE350B",
+                                              "dangerLight": "#FFBDAD",
+                                              "neutral0": "hsl(0, 0%, 100%)",
+                                              "neutral10": "hsl(0, 0%, 90%)",
+                                              "neutral20": "hsl(0, 0%, 80%)",
+                                              "neutral30": "hsl(0, 0%, 70%)",
+                                              "neutral40": "hsl(0, 0%, 60%)",
+                                              "neutral5": "hsl(0, 0%, 95%)",
+                                              "neutral50": "hsl(0, 0%, 50%)",
+                                              "neutral60": "hsl(0, 0%, 40%)",
+                                              "neutral70": "hsl(0, 0%, 30%)",
+                                              "neutral80": "hsl(0, 0%, 20%)",
+                                              "neutral90": "hsl(0, 0%, 10%)",
+                                              "primary": "#2684FF",
+                                              "primary25": "#DEEBFF",
+                                              "primary50": "#B2D4FF",
+                                              "primary75": "#4C9AFF",
+                                            },
+                                            "spacing": Object {
+                                              "baseUnit": 4,
+                                              "controlHeight": 38,
+                                              "menuGutter": 8,
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <EmotionCssPropInternal
+                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                          className=""
+                                          css={
+                                            Object {
+                                              "WebkitOverflowScrolling": "touch",
+                                              "alignItems": "center",
+                                              "boxSizing": "border-box",
+                                              "display": "flex",
+                                              "flex": 1,
+                                              "flexWrap": "wrap",
+                                              "overflow": "hidden",
+                                              "padding": "0 10px",
+                                              "position": "relative",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=" css-1gbz4ua"
+                                          >
+                                            <SingleValue
+                                              clearValue={[Function]}
+                                              cx={[Function]}
+                                              data={
+                                                Object {
+                                                  "label": "5",
+                                                  "value": 5,
+                                                }
+                                              }
+                                              getStyles={[Function]}
+                                              getValue={[Function]}
+                                              hasValue={true}
+                                              isDisabled={false}
+                                              isMulti={false}
+                                              isRtl={false}
+                                              options={
+                                                Array [
+                                                  Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                  Object {
+                                                    "label": "20",
+                                                    "value": 20,
+                                                  },
+                                                  Object {
+                                                    "label": "50",
+                                                    "value": 50,
+                                                  },
+                                                ]
+                                              }
+                                              selectOption={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              setValue={[Function]}
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SingleValue"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                className=""
+                                                css={
+                                                  Object {
+                                                    "boxSizing": "border-box",
+                                                    "color": "inherit",
+                                                    "label": "singleValue",
+                                                    "marginLeft": 2,
+                                                    "marginRight": 2,
+                                                    "maxWidth": "calc(100% - 8px)",
+                                                    "overflow": "hidden",
+                                                    "position": "absolute",
+                                                    "textOverflow": "ellipsis",
+                                                    "top": "50%",
+                                                    "transform": "translateY(-50%)",
+                                                    "whiteSpace": "nowrap",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className=" css-1xqm9c7-singleValue"
+                                                >
+                                                  5
+                                                </div>
+                                              </EmotionCssPropInternal>
+                                            </SingleValue>
+                                            <Input
+                                              aria-autocomplete="list"
+                                              autoCapitalize="none"
+                                              autoComplete="off"
+                                              autoCorrect="off"
+                                              cx={[Function]}
+                                              getStyles={[Function]}
+                                              id="react-select-3-input"
+                                              innerRef={[Function]}
+                                              isDisabled={false}
+                                              isHidden={false}
+                                              onBlur={[Function]}
+                                              onChange={[Function]}
+                                              onFocus={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              spellCheck="false"
+                                              tabIndex="0"
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                              type="text"
+                                              value=""
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                css={
+                                                  Object {
+                                                    "boxSizing": "border-box",
+                                                    "color": "hsl(0, 0%, 20%)",
+                                                    "margin": 2,
+                                                    "paddingBottom": 2,
+                                                    "paddingTop": 2,
+                                                    "visibility": "visible",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className="css-b8ldur-Input"
+                                                >
+                                                  <AutosizeInput
+                                                    aria-autocomplete="list"
+                                                    autoCapitalize="none"
+                                                    autoComplete="off"
+                                                    autoCorrect="off"
+                                                    className=""
+                                                    disabled={false}
+                                                    id="react-select-3-input"
+                                                    injectStyles={true}
+                                                    inputRef={[Function]}
+                                                    inputStyle={
+                                                      Object {
+                                                        "background": 0,
+                                                        "border": 0,
+                                                        "color": "inherit",
+                                                        "fontSize": "inherit",
+                                                        "label": "input",
+                                                        "opacity": 1,
+                                                        "outline": 0,
+                                                        "padding": 0,
+                                                      }
+                                                    }
+                                                    minWidth={1}
+                                                    onBlur={[Function]}
+                                                    onChange={[Function]}
+                                                    onFocus={[Function]}
+                                                    spellCheck="false"
+                                                    tabIndex="0"
+                                                    type="text"
+                                                    value=""
+                                                  >
+                                                    <div
+                                                      className=""
+                                                      style={
+                                                        Object {
+                                                          "display": "inline-block",
+                                                        }
+                                                      }
+                                                    >
+                                                      <input
+                                                        aria-autocomplete="list"
+                                                        autoCapitalize="none"
+                                                        autoComplete="off"
+                                                        autoCorrect="off"
+                                                        disabled={false}
+                                                        id="react-select-3-input"
+                                                        onBlur={[Function]}
+                                                        onChange={[Function]}
+                                                        onFocus={[Function]}
+                                                        spellCheck="false"
+                                                        style={
+                                                          Object {
+                                                            "background": 0,
+                                                            "border": 0,
+                                                            "boxSizing": "content-box",
+                                                            "color": "inherit",
+                                                            "fontSize": "inherit",
+                                                            "label": "input",
+                                                            "opacity": 1,
+                                                            "outline": 0,
+                                                            "padding": 0,
+                                                            "width": "2px",
+                                                          }
+                                                        }
+                                                        tabIndex="0"
+                                                        type="text"
+                                                        value=""
+                                                      />
+                                                      <div
+                                                        style={
+                                                          Object {
+                                                            "height": 0,
+                                                            "left": 0,
+                                                            "overflow": "scroll",
+                                                            "position": "absolute",
+                                                            "top": 0,
+                                                            "visibility": "hidden",
+                                                            "whiteSpace": "pre",
+                                                          }
+                                                        }
+                                                      />
+                                                    </div>
+                                                  </AutosizeInput>
+                                                </div>
+                                              </EmotionCssPropInternal>
+                                            </Input>
+                                          </div>
+                                        </EmotionCssPropInternal>
+                                      </ValueContainer>
+                                      <IndicatorsContainer
+                                        clearValue={[Function]}
+                                        cx={[Function]}
+                                        getStyles={[Function]}
+                                        getValue={[Function]}
+                                        hasValue={true}
+                                        isDisabled={false}
+                                        isMulti={false}
+                                        isRtl={false}
+                                        options={
+                                          Array [
+                                            Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                            Object {
+                                              "label": "20",
+                                              "value": 20,
+                                            },
+                                            Object {
+                                              "label": "50",
+                                              "value": 50,
+                                            },
+                                          ]
+                                        }
+                                        selectOption={[Function]}
+                                        selectProps={
+                                          Object {
+                                            "backspaceRemovesValue": true,
+                                            "blurInputOnSelect": true,
+                                            "borderless": true,
+                                            "captureMenuScroll": false,
+                                            "closeMenuOnScroll": false,
+                                            "closeMenuOnSelect": true,
+                                            "components": Object {
+                                              "Option": [Function],
+                                            },
+                                            "controlShouldRenderValue": true,
+                                            "escapeClearsValue": false,
+                                            "filterOption": [Function],
+                                            "formatGroupLabel": [Function],
+                                            "getOptionLabel": [Function],
+                                            "getOptionValue": [Function],
+                                            "icon": undefined,
+                                            "inputValue": "",
+                                            "isDisabled": false,
+                                            "isLoading": false,
+                                            "isMulti": false,
+                                            "isOptionDisabled": [Function],
+                                            "isRtl": false,
+                                            "isSearchable": true,
+                                            "loadingMessage": [Function],
+                                            "maxMenuHeight": 300,
+                                            "menuIsOpen": false,
+                                            "menuPlacement": "auto",
+                                            "menuPosition": "absolute",
+                                            "menuShouldBlockScroll": false,
+                                            "menuShouldScrollIntoView": true,
+                                            "minMenuHeight": 140,
+                                            "noOptionsMessage": [Function],
+                                            "onChange": [Function],
+                                            "onInputChange": [Function],
+                                            "onMenuClose": [Function],
+                                            "onMenuOpen": [Function],
+                                            "openMenuOnClick": true,
+                                            "openMenuOnFocus": false,
+                                            "options": Array [
+                                              Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                              Object {
+                                                "label": "20",
+                                                "value": 20,
+                                              },
+                                              Object {
+                                                "label": "50",
+                                                "value": 50,
+                                              },
+                                            ],
+                                            "pageSize": 5,
+                                            "placeholder": "Select...",
+                                            "screenReaderStatus": [Function],
+                                            "styles": Object {
+                                              "clearIndicator": [Function],
+                                              "container": [Function],
+                                              "control": [Function],
+                                              "dropdownIndicator": [Function],
+                                              "indicatorSeparator": [Function],
+                                              "indicatorsContainer": [Function],
+                                              "menu": [Function],
+                                              "menuList": [Function],
+                                              "menuPortal": [Function],
+                                              "option": [Function],
+                                              "singleValue": [Function],
+                                              "valueContainer": [Function],
+                                            },
+                                            "tabIndex": "0",
+                                            "tabSelectsValue": true,
+                                            "value": Object {
+                                              "label": "5",
+                                              "value": 5,
+                                            },
+                                          }
+                                        }
+                                        setValue={[Function]}
+                                        theme={
+                                          Object {
+                                            "borderRadius": 4,
+                                            "colors": Object {
+                                              "danger": "#DE350B",
+                                              "dangerLight": "#FFBDAD",
+                                              "neutral0": "hsl(0, 0%, 100%)",
+                                              "neutral10": "hsl(0, 0%, 90%)",
+                                              "neutral20": "hsl(0, 0%, 80%)",
+                                              "neutral30": "hsl(0, 0%, 70%)",
+                                              "neutral40": "hsl(0, 0%, 60%)",
+                                              "neutral5": "hsl(0, 0%, 95%)",
+                                              "neutral50": "hsl(0, 0%, 50%)",
+                                              "neutral60": "hsl(0, 0%, 40%)",
+                                              "neutral70": "hsl(0, 0%, 30%)",
+                                              "neutral80": "hsl(0, 0%, 20%)",
+                                              "neutral90": "hsl(0, 0%, 10%)",
+                                              "primary": "#2684FF",
+                                              "primary25": "#DEEBFF",
+                                              "primary50": "#B2D4FF",
+                                              "primary75": "#4C9AFF",
+                                            },
+                                            "spacing": Object {
+                                              "baseUnit": 4,
+                                              "controlHeight": 38,
+                                              "menuGutter": 8,
+                                            },
+                                          }
+                                        }
+                                      >
+                                        <EmotionCssPropInternal
+                                          __EMOTION_LABEL_PLEASE_DO_NOT_USE__="IndicatorsContainer"
+                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                          className=""
+                                          css={
+                                            Object {
+                                              "alignItems": "center",
+                                              "alignSelf": "stretch",
+                                              "boxSizing": "border-box",
+                                              "color": "#b6bbc7",
+                                              "display": "flex",
+                                              "flexShrink": 0,
+                                              "marginRight": "5px",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className=" css-1y4h2k2-IndicatorsContainer"
+                                          >
+                                            <IndicatorSeparator
+                                              clearValue={[Function]}
+                                              cx={[Function]}
+                                              getStyles={[Function]}
+                                              getValue={[Function]}
+                                              hasValue={true}
+                                              isDisabled={false}
+                                              isFocused={false}
+                                              isMulti={false}
+                                              isRtl={false}
+                                              options={
+                                                Array [
+                                                  Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                  Object {
+                                                    "label": "20",
+                                                    "value": 20,
+                                                  },
+                                                  Object {
+                                                    "label": "50",
+                                                    "value": 50,
+                                                  },
+                                                ]
+                                              }
+                                              selectOption={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              setValue={[Function]}
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="IndicatorSeparator"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="span"
+                                                className=""
+                                                css={
+                                                  Object {
+                                                    "display": "none",
+                                                  }
+                                                }
+                                              >
+                                                <span
+                                                  className=" css-1xjgjl1-IndicatorSeparator"
+                                                />
+                                              </EmotionCssPropInternal>
+                                            </IndicatorSeparator>
+                                            <DropdownIndicator
+                                              clearValue={[Function]}
+                                              cx={[Function]}
+                                              getStyles={[Function]}
+                                              getValue={[Function]}
+                                              hasValue={true}
+                                              innerProps={
+                                                Object {
+                                                  "aria-hidden": "true",
+                                                  "onMouseDown": [Function],
+                                                  "onTouchEnd": [Function],
+                                                }
+                                              }
+                                              isDisabled={false}
+                                              isFocused={false}
+                                              isMulti={false}
+                                              isRtl={false}
+                                              options={
+                                                Array [
+                                                  Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                  Object {
+                                                    "label": "20",
+                                                    "value": 20,
+                                                  },
+                                                  Object {
+                                                    "label": "50",
+                                                    "value": 50,
+                                                  },
+                                                ]
+                                              }
+                                              selectOption={[Function]}
+                                              selectProps={
+                                                Object {
+                                                  "backspaceRemovesValue": true,
+                                                  "blurInputOnSelect": true,
+                                                  "borderless": true,
+                                                  "captureMenuScroll": false,
+                                                  "closeMenuOnScroll": false,
+                                                  "closeMenuOnSelect": true,
+                                                  "components": Object {
+                                                    "Option": [Function],
+                                                  },
+                                                  "controlShouldRenderValue": true,
+                                                  "escapeClearsValue": false,
+                                                  "filterOption": [Function],
+                                                  "formatGroupLabel": [Function],
+                                                  "getOptionLabel": [Function],
+                                                  "getOptionValue": [Function],
+                                                  "icon": undefined,
+                                                  "inputValue": "",
+                                                  "isDisabled": false,
+                                                  "isLoading": false,
+                                                  "isMulti": false,
+                                                  "isOptionDisabled": [Function],
+                                                  "isRtl": false,
+                                                  "isSearchable": true,
+                                                  "loadingMessage": [Function],
+                                                  "maxMenuHeight": 300,
+                                                  "menuIsOpen": false,
+                                                  "menuPlacement": "auto",
+                                                  "menuPosition": "absolute",
+                                                  "menuShouldBlockScroll": false,
+                                                  "menuShouldScrollIntoView": true,
+                                                  "minMenuHeight": 140,
+                                                  "noOptionsMessage": [Function],
+                                                  "onChange": [Function],
+                                                  "onInputChange": [Function],
+                                                  "onMenuClose": [Function],
+                                                  "onMenuOpen": [Function],
+                                                  "openMenuOnClick": true,
+                                                  "openMenuOnFocus": false,
+                                                  "options": Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ],
+                                                  "pageSize": 5,
+                                                  "placeholder": "Select...",
+                                                  "screenReaderStatus": [Function],
+                                                  "styles": Object {
+                                                    "clearIndicator": [Function],
+                                                    "container": [Function],
+                                                    "control": [Function],
+                                                    "dropdownIndicator": [Function],
+                                                    "indicatorSeparator": [Function],
+                                                    "indicatorsContainer": [Function],
+                                                    "menu": [Function],
+                                                    "menuList": [Function],
+                                                    "menuPortal": [Function],
+                                                    "option": [Function],
+                                                    "singleValue": [Function],
+                                                    "valueContainer": [Function],
+                                                  },
+                                                  "tabIndex": "0",
+                                                  "tabSelectsValue": true,
+                                                  "value": Object {
+                                                    "label": "5",
+                                                    "value": 5,
+                                                  },
+                                                }
+                                              }
+                                              setValue={[Function]}
+                                              theme={
+                                                Object {
+                                                  "borderRadius": 4,
+                                                  "colors": Object {
+                                                    "danger": "#DE350B",
+                                                    "dangerLight": "#FFBDAD",
+                                                    "neutral0": "hsl(0, 0%, 100%)",
+                                                    "neutral10": "hsl(0, 0%, 90%)",
+                                                    "neutral20": "hsl(0, 0%, 80%)",
+                                                    "neutral30": "hsl(0, 0%, 70%)",
+                                                    "neutral40": "hsl(0, 0%, 60%)",
+                                                    "neutral5": "hsl(0, 0%, 95%)",
+                                                    "neutral50": "hsl(0, 0%, 50%)",
+                                                    "neutral60": "hsl(0, 0%, 40%)",
+                                                    "neutral70": "hsl(0, 0%, 30%)",
+                                                    "neutral80": "hsl(0, 0%, 20%)",
+                                                    "neutral90": "hsl(0, 0%, 10%)",
+                                                    "primary": "#2684FF",
+                                                    "primary25": "#DEEBFF",
+                                                    "primary50": "#B2D4FF",
+                                                    "primary75": "#4C9AFF",
+                                                  },
+                                                  "spacing": Object {
+                                                    "baseUnit": 4,
+                                                    "controlHeight": 38,
+                                                    "menuGutter": 8,
+                                                  },
+                                                }
+                                              }
+                                            >
+                                              <EmotionCssPropInternal
+                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
+                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                aria-hidden="true"
+                                                className=""
+                                                css={
+                                                  Object {
+                                                    "color": "#b6bbc7",
+                                                    "display": "flex",
+                                                    "margin": "5px",
+                                                    "padding": "0",
+                                                  }
+                                                }
+                                                onMouseDown={[Function]}
+                                                onTouchEnd={[Function]}
+                                              >
+                                                <div
+                                                  aria-hidden="true"
+                                                  className=" css-1vd5qh6-DropdownIndicator"
+                                                  onMouseDown={[Function]}
+                                                  onTouchEnd={[Function]}
+                                                >
+                                                  <DownChevron>
+                                                    <Svg
+                                                      size={20}
+                                                    >
+                                                      <EmotionCssPropInternal
+                                                        __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
+                                                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
+                                                        aria-hidden="true"
+                                                        css={
+                                                          Object {
+                                                            "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
+                                                            "name": "19bqh2r",
+                                                            "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
+                                                          }
+                                                        }
+                                                        focusable="false"
+                                                        height={20}
+                                                        viewBox="0 0 20 20"
+                                                        width={20}
+                                                      >
+                                                        <svg
+                                                          aria-hidden="true"
+                                                          className="css-6q0nyr-Svg"
+                                                          focusable="false"
+                                                          height={20}
+                                                          viewBox="0 0 20 20"
+                                                          width={20}
+                                                        >
+                                                          <path
+                                                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                                          />
+                                                        </svg>
+                                                      </EmotionCssPropInternal>
+                                                    </Svg>
+                                                  </DownChevron>
+                                                </div>
+                                              </EmotionCssPropInternal>
+                                            </DropdownIndicator>
+                                          </div>
+                                        </EmotionCssPropInternal>
+                                      </IndicatorsContainer>
+                                    </div>
+                                  </EmotionCssPropInternal>
+                                </Control>
+                              </div>
+                            </EmotionCssPropInternal>
+                          </SelectContainer>
+                        </Select>
+                      </StateManager>
+                    </SelectController>
+                  </Select>
+                </div>
+              </StyledComponent>
+            </styled__RowPerPageWrapper>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 5 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c3",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c3"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c4",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c4"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c5",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c5"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={false}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={false}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={false}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={false}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c3",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c3"
+                      disabled={false}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c4",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c4"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c5",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c5"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+  </div>
+</Table>
+`;
+
+exports[`Table handlePageChange should set page and rowsPerPage when invoked 1`] = `
+.c5 {
+  background-color: #ffffff;
+  border-collapse: collapse;
+  border: none;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.c7 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+  width: 33%;
+}
+
+.c8 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c9 {
+  background-color: #f0f0f7;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c11 {
+  background-color: inherit;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c6 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c6 td,
+.c6 th {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 200;
+}
+
+.c10 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c3 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  position: relative;
+  overflow: hidden;
+  min-width: 14px;
+}
+
+.c4 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  opacity: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 18px;
+  outline: none;
+  padding: 10px 20px;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  white-space: nowrap;
+  background-color: transparent;
+  border-color: transparent;
+  color: #6124e2;
+}
+
+.c2:hover {
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.1);
+}
+
+.c2:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.15);
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  border-color: transparent;
+  color: #b6bbc7;
+}
+
+.c2:focus-visible {
+  box-shadow: rgba(0,0,0,0.15) 0 0 0 2px;
+}
+
+.c1 {
+  color: #555e6f;
+  display: inline-block;
+  font-size: 14px;
+  font-stretch: normal;
+  font-style: normal;
+  font-weight: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  margin: 5px 5px 5px 0;
+  color: #8e929b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+<Table
+  data={
+    Array [
+      Object {
+        "dob": "1942-11-30",
+        "id": "1",
+        "lastUpdated": "2019-09-01",
+        "manager": "Spongebob",
+        "name": "Eugene Krabs",
+      },
+      Object {
+        "dob": "",
+        "id": "2",
+        "lastUpdated": "2019-08-29",
+        "manager": "Smitty",
+        "name": "Squidward Tentacles",
+      },
+      Object {
+        "dob": "1987-11-17",
+        "id": "3",
+        "lastUpdated": "2019-07-30",
+        "manager": "Patrick",
+        "name": "Sandy Cheeks",
+      },
+      Object {
+        "dob": "1975-06-23",
+        "id": "4",
+        "lastUpdated": "2019-08-16",
+        "manager": "Patchy",
+        "name": "Larry the Lobster",
+      },
+      Object {
+        "dob": "1942-11-30",
+        "id": "5",
+        "lastUpdated": "2019-08-20",
+        "manager": "Spongebob",
+        "name": "Sheldon Plankton",
+      },
+      Object {
+        "dob": "",
+        "id": "6",
+        "lastUpdated": "2019-08-21",
+        "manager": "Spongebob",
+        "name": "Mrs. Puff",
+      },
+      Object {
+        "dob": "1678-04-20",
+        "id": "7",
+        "lastUpdated": "2019-06-21",
+        "manager": "Spongebob",
+        "name": "Flying Dutchman",
+      },
+    ]
+  }
+  headers={
+    Array [
+      Object {
+        "cellStyle": Object {
+          "width": "33%",
+        },
+        "key": "name",
+        "label": "Subject Name",
+      },
+      Object {
+        "key": "dob",
+        "label": "Date of Birth",
+      },
+      Object {
+        "key": "manager",
+        "label": "Manager",
+      },
+      Object {
+        "key": "lastUpdated",
+        "label": "Last Updated",
+      },
+      Object {
+        "key": "id",
+        "label": "ID",
+        "sortable": false,
+      },
+    ]
+  }
+  paginated={true}
+>
+  <div>
+    <PaginationToolbar
+      count={7}
+      onPageChange={[Function]}
+      page={0}
+      rowsPerPage={7}
+      rowsPerPageOptions={Array []}
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 7 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+    <styled__StyledTable>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "styled__StyledTable-r3xwjs-0",
+              "isStatic": false,
+              "lastClassName": "c5",
+              "rules": Array [
+                "background-color:",
+                "#ffffff",
+                ";border-collapse:collapse;border:none;table-layout:fixed;width:100%;",
+              ],
+            },
+            "displayName": "styled__StyledTable",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "styled__StyledTable-r3xwjs-0",
+            "target": "table",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+      >
+        <table
+          className="c5"
+        >
+          <TableHeader
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c11",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            onSort={[Function]}
+            order={false}
+            sticky={true}
+          >
+            <thead>
+              <styled__StyledRow
+                sticky={true}
+              >
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__StyledRow-r3xwjs-3",
+                        "isStatic": false,
+                        "lastClassName": "c10",
+                        "rules": Array [
+                          "background-color:",
+                          "#ffffff",
+                          ";border-bottom:1px solid ",
+                          "#dcdce7",
+                          ";td,th{",
+                          [Function],
+                          "};",
+                        ],
+                      },
+                      "displayName": "styled__StyledRow",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                      "target": "tr",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  sticky={true}
+                >
+                  <tr
+                    className="c6"
+                  >
+                    <HeadCell
+                      cellStyle={
+                        Object {
+                          "width": "33%",
+                        }
+                      }
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="name"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={
+                          Object {
+                            "width": "33%",
+                          }
+                        }
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={
+                            Object {
+                              "width": "33%",
+                            }
+                          }
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c7"
+                            onClick={[Function]}
+                          >
+                            Subject Name
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="dob"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Date of Birth
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="manager"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Manager
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="lastUpdated"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Last Updated
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="id"
+                      order={false}
+                      sortable={false}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <th
+                            className="c9"
+                          >
+                            ID
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                  </tr>
+                </StyledComponent>
+              </styled__StyledRow>
+            </thead>
+          </TableHeader>
+          <TableBody
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c11",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            data={
+              Array [
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "1",
+                  "lastUpdated": "2019-09-01",
+                  "manager": "Spongebob",
+                  "name": "Eugene Krabs",
+                },
+                Object {
+                  "dob": "",
+                  "id": "2",
+                  "lastUpdated": "2019-08-29",
+                  "manager": "Smitty",
+                  "name": "Squidward Tentacles",
+                },
+                Object {
+                  "dob": "1987-11-17",
+                  "id": "3",
+                  "lastUpdated": "2019-07-30",
+                  "manager": "Patrick",
+                  "name": "Sandy Cheeks",
+                },
+                Object {
+                  "dob": "1975-06-23",
+                  "id": "4",
+                  "lastUpdated": "2019-08-16",
+                  "manager": "Patchy",
+                  "name": "Larry the Lobster",
+                },
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "5",
+                  "lastUpdated": "2019-08-20",
+                  "manager": "Spongebob",
+                  "name": "Sheldon Plankton",
+                },
+                Object {
+                  "dob": "",
+                  "id": "6",
+                  "lastUpdated": "2019-08-21",
+                  "manager": "Spongebob",
+                  "name": "Mrs. Puff",
+                },
+                Object {
+                  "dob": "1678-04-20",
+                  "id": "7",
+                  "lastUpdated": "2019-06-21",
+                  "manager": "Spongebob",
+                  "name": "Flying Dutchman",
+                },
+              ]
+            }
+            exact={false}
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            page={0}
+            rowsPerPage={7}
+          >
+            <tbody>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "1",
+                    "lastUpdated": "2019-09-01",
+                    "manager": "Spongebob",
+                    "name": "Eugene Krabs",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="1"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="1_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Eugene Krabs
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-09-01
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "2",
+                    "lastUpdated": "2019-08-29",
+                    "manager": "Smitty",
+                    "name": "Squidward Tentacles",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="2"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="2_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Squidward Tentacles
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Smitty
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-29
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1987-11-17",
+                    "id": "3",
+                    "lastUpdated": "2019-07-30",
+                    "manager": "Patrick",
+                    "name": "Sandy Cheeks",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="3"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="3_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sandy Cheeks
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1987-11-17
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patrick
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-07-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            3
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1975-06-23",
+                    "id": "4",
+                    "lastUpdated": "2019-08-16",
+                    "manager": "Patchy",
+                    "name": "Larry the Lobster",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="4"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="4_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Larry the Lobster
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1975-06-23
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patchy
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-16
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            4
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "5",
+                    "lastUpdated": "2019-08-20",
+                    "manager": "Spongebob",
+                    "name": "Sheldon Plankton",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="5"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="5_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sheldon Plankton
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            5
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "6",
+                    "lastUpdated": "2019-08-21",
+                    "manager": "Spongebob",
+                    "name": "Mrs. Puff",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="6"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="6_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Mrs. Puff
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            6
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1678-04-20",
+                    "id": "7",
+                    "lastUpdated": "2019-06-21",
+                    "manager": "Spongebob",
+                    "name": "Flying Dutchman",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="7"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="7_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Flying Dutchman
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1678-04-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-06-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            7
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+            </tbody>
+          </TableBody>
+        </table>
+      </StyledComponent>
+    </styled__StyledTable>
+    <PaginationToolbar
+      count={7}
+      onPageChange={[Function]}
+      page={0}
+      rowsPerPage={7}
+      rowsPerPageOptions={Array []}
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 7 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+  </div>
+</Table>
+`;
+
+exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "column": "name",
+        "descending": true,
+        "page": 0,
+        "rowsPerPage": 7,
+        "start": 0,
+      },
+      Object {
+        "target": "mock",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`Table handleSort should invoke onSort with property and isDesc 2`] = `
+.c5 {
+  background-color: #ffffff;
+  border-collapse: collapse;
+  border: none;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.c7 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+  width: 33%;
+}
+
+.c8 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c9 {
+  background-color: #f0f0f7;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c11 {
+  background-color: inherit;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c6 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c6 td,
+.c6 th {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 200;
+}
+
+.c10 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c3 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  position: relative;
+  overflow: hidden;
+  min-width: 14px;
+}
+
+.c4 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  opacity: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 18px;
+  outline: none;
+  padding: 10px 20px;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  white-space: nowrap;
+  background-color: transparent;
+  border-color: transparent;
+  color: #6124e2;
+}
+
+.c2:hover {
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.1);
+}
+
+.c2:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.15);
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  border-color: transparent;
+  color: #b6bbc7;
+}
+
+.c2:focus-visible {
+  box-shadow: rgba(0,0,0,0.15) 0 0 0 2px;
+}
+
+.c1 {
+  color: #555e6f;
+  display: inline-block;
+  font-size: 14px;
+  font-stretch: normal;
+  font-style: normal;
+  font-weight: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  margin: 5px 5px 5px 0;
+  color: #8e929b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+<Table
+  data={
+    Array [
+      Object {
+        "dob": "1942-11-30",
+        "id": "1",
+        "lastUpdated": "2019-09-01",
+        "manager": "Spongebob",
+        "name": "Eugene Krabs",
+      },
+      Object {
+        "dob": "",
+        "id": "2",
+        "lastUpdated": "2019-08-29",
+        "manager": "Smitty",
+        "name": "Squidward Tentacles",
+      },
+      Object {
+        "dob": "1987-11-17",
+        "id": "3",
+        "lastUpdated": "2019-07-30",
+        "manager": "Patrick",
+        "name": "Sandy Cheeks",
+      },
+      Object {
+        "dob": "1975-06-23",
+        "id": "4",
+        "lastUpdated": "2019-08-16",
+        "manager": "Patchy",
+        "name": "Larry the Lobster",
+      },
+      Object {
+        "dob": "1942-11-30",
+        "id": "5",
+        "lastUpdated": "2019-08-20",
+        "manager": "Spongebob",
+        "name": "Sheldon Plankton",
+      },
+      Object {
+        "dob": "",
+        "id": "6",
+        "lastUpdated": "2019-08-21",
+        "manager": "Spongebob",
+        "name": "Mrs. Puff",
+      },
+      Object {
+        "dob": "1678-04-20",
+        "id": "7",
+        "lastUpdated": "2019-06-21",
+        "manager": "Spongebob",
+        "name": "Flying Dutchman",
+      },
+    ]
+  }
+  headers={
+    Array [
+      Object {
+        "cellStyle": Object {
+          "width": "33%",
+        },
+        "key": "name",
+        "label": "Subject Name",
+      },
+      Object {
+        "key": "dob",
+        "label": "Date of Birth",
+      },
+      Object {
+        "key": "manager",
+        "label": "Manager",
+      },
+      Object {
+        "key": "lastUpdated",
+        "label": "Last Updated",
+      },
+      Object {
+        "key": "id",
+        "label": "ID",
+        "sortable": false,
+      },
+    ]
+  }
+  onSort={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "column": "name",
+            "descending": true,
+            "page": 0,
+            "rowsPerPage": 7,
+            "start": 0,
+          },
+          Object {
+            "target": "mock",
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  paginated={true}
+>
+  <div>
+    <PaginationToolbar
+      count={7}
+      onPageChange={[Function]}
+      page={0}
+      rowsPerPage={7}
+      rowsPerPageOptions={Array []}
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 7 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+    <styled__StyledTable>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "styled__StyledTable-r3xwjs-0",
+              "isStatic": false,
+              "lastClassName": "c5",
+              "rules": Array [
+                "background-color:",
+                "#ffffff",
+                ";border-collapse:collapse;border:none;table-layout:fixed;width:100%;",
+              ],
+            },
+            "displayName": "styled__StyledTable",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "styled__StyledTable-r3xwjs-0",
+            "target": "table",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+      >
+        <table
+          className="c5"
+        >
+          <TableHeader
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c11",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            onSort={[Function]}
+            order={false}
+            sticky={true}
+          >
+            <thead>
+              <styled__StyledRow
+                sticky={true}
+              >
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__StyledRow-r3xwjs-3",
+                        "isStatic": false,
+                        "lastClassName": "c10",
+                        "rules": Array [
+                          "background-color:",
+                          "#ffffff",
+                          ";border-bottom:1px solid ",
+                          "#dcdce7",
+                          ";td,th{",
+                          [Function],
+                          "};",
+                        ],
+                      },
+                      "displayName": "styled__StyledRow",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                      "target": "tr",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  sticky={true}
+                >
+                  <tr
+                    className="c6"
+                  >
+                    <HeadCell
+                      cellStyle={
+                        Object {
+                          "width": "33%",
+                        }
+                      }
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="name"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={
+                          Object {
+                            "width": "33%",
+                          }
+                        }
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={
+                            Object {
+                              "width": "33%",
+                            }
+                          }
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c7"
+                            onClick={[Function]}
+                          >
+                            Subject Name
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="dob"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Date of Birth
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="manager"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Manager
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="lastUpdated"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Last Updated
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="id"
+                      order={false}
+                      sortable={false}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <th
+                            className="c9"
+                          >
+                            ID
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                  </tr>
+                </StyledComponent>
+              </styled__StyledRow>
+            </thead>
+          </TableHeader>
+          <TableBody
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c11",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            data={
+              Array [
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "1",
+                  "lastUpdated": "2019-09-01",
+                  "manager": "Spongebob",
+                  "name": "Eugene Krabs",
+                },
+                Object {
+                  "dob": "",
+                  "id": "2",
+                  "lastUpdated": "2019-08-29",
+                  "manager": "Smitty",
+                  "name": "Squidward Tentacles",
+                },
+                Object {
+                  "dob": "1987-11-17",
+                  "id": "3",
+                  "lastUpdated": "2019-07-30",
+                  "manager": "Patrick",
+                  "name": "Sandy Cheeks",
+                },
+                Object {
+                  "dob": "1975-06-23",
+                  "id": "4",
+                  "lastUpdated": "2019-08-16",
+                  "manager": "Patchy",
+                  "name": "Larry the Lobster",
+                },
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "5",
+                  "lastUpdated": "2019-08-20",
+                  "manager": "Spongebob",
+                  "name": "Sheldon Plankton",
+                },
+                Object {
+                  "dob": "",
+                  "id": "6",
+                  "lastUpdated": "2019-08-21",
+                  "manager": "Spongebob",
+                  "name": "Mrs. Puff",
+                },
+                Object {
+                  "dob": "1678-04-20",
+                  "id": "7",
+                  "lastUpdated": "2019-06-21",
+                  "manager": "Spongebob",
+                  "name": "Flying Dutchman",
+                },
+              ]
+            }
+            exact={false}
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            page={0}
+            rowsPerPage={7}
+          >
+            <tbody>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "1",
+                    "lastUpdated": "2019-09-01",
+                    "manager": "Spongebob",
+                    "name": "Eugene Krabs",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="1"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="1_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Eugene Krabs
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-09-01
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "2",
+                    "lastUpdated": "2019-08-29",
+                    "manager": "Smitty",
+                    "name": "Squidward Tentacles",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="2"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="2_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Squidward Tentacles
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Smitty
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-29
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1987-11-17",
+                    "id": "3",
+                    "lastUpdated": "2019-07-30",
+                    "manager": "Patrick",
+                    "name": "Sandy Cheeks",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="3"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="3_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sandy Cheeks
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1987-11-17
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patrick
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-07-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            3
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1975-06-23",
+                    "id": "4",
+                    "lastUpdated": "2019-08-16",
+                    "manager": "Patchy",
+                    "name": "Larry the Lobster",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="4"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="4_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Larry the Lobster
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1975-06-23
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patchy
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-16
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            4
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "5",
+                    "lastUpdated": "2019-08-20",
+                    "manager": "Spongebob",
+                    "name": "Sheldon Plankton",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="5"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="5_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sheldon Plankton
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            5
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "6",
+                    "lastUpdated": "2019-08-21",
+                    "manager": "Spongebob",
+                    "name": "Mrs. Puff",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="6"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="6_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Mrs. Puff
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            6
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1678-04-20",
+                    "id": "7",
+                    "lastUpdated": "2019-06-21",
+                    "manager": "Spongebob",
+                    "name": "Flying Dutchman",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="7"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="7_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Flying Dutchman
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1678-04-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-06-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            7
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+            </tbody>
+          </TableBody>
+        </table>
+      </StyledComponent>
+    </styled__StyledTable>
+    <PaginationToolbar
+      count={7}
+      onPageChange={[Function]}
+      page={0}
+      rowsPerPage={7}
+      rowsPerPageOptions={Array []}
     >
       <styled__PaginationWrapper>
         <StyledComponent
@@ -4995,81 +21051,10 @@ exports[`Table handleSort should set order and orderBy when invoked 1`] = `
   <div>
     <PaginationToolbar
       count={7}
+      onPageChange={[Function]}
       page={0}
       rowsPerPage={7}
       rowsPerPageOptions={Array []}
-      setPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setRowsPerPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
     >
       <styled__PaginationWrapper>
         <StyledComponent
@@ -8676,81 +24661,10 @@ exports[`Table handleSort should set order and orderBy when invoked 1`] = `
     </styled__StyledTable>
     <PaginationToolbar
       count={7}
+      onPageChange={[Function]}
       page={0}
       rowsPerPage={7}
       rowsPerPageOptions={Array []}
-      setPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setRowsPerPage={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              0,
-            ],
-            Array [
-              7,
-            ],
-            Array [
-              "desc",
-            ],
-            Array [
-              "name",
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
     >
       <styled__PaginationWrapper>
         <StyledComponent
@@ -9550,10 +25464,9 @@ exports[`Table props paginated Table should set rowsPerPage to data.length when 
 exports[`Table props paginated paginated Table should set rowsPerPage to 5 by default 1`] = `
 <div>
   <Memo(PaginationToolbar)
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={5}
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
   <styled__StyledTable>
     <TableHeader
@@ -9695,10 +25608,9 @@ exports[`Table props paginated paginated Table should set rowsPerPage to 5 by de
     />
   </styled__StyledTable>
   <Memo(PaginationToolbar)
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={5}
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
 </div>
 `;
@@ -9707,10 +25619,9 @@ exports[`Table props paginated paginated Table should set rowsPerPage to data.le
 <div>
   <Memo(PaginationToolbar)
     count={7}
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={7}
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
   <styled__StyledTable>
     <TableHeader
@@ -9906,10 +25817,9 @@ exports[`Table props paginated paginated Table should set rowsPerPage to data.le
   </styled__StyledTable>
   <Memo(PaginationToolbar)
     count={7}
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={7}
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
 </div>
 `;
@@ -9918,6 +25828,7 @@ exports[`Table props paginated paginated Table should set rowsPerPage to first e
 <div>
   <Memo(PaginationToolbar)
     count={7}
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={10}
     rowsPerPageOptions={
@@ -9927,8 +25838,6 @@ exports[`Table props paginated paginated Table should set rowsPerPage to first e
         100,
       ]
     }
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
   <styled__StyledTable>
     <TableHeader
@@ -10124,6 +26033,7 @@ exports[`Table props paginated paginated Table should set rowsPerPage to first e
   </styled__StyledTable>
   <Memo(PaginationToolbar)
     count={7}
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={10}
     rowsPerPageOptions={
@@ -10133,8 +26043,6 @@ exports[`Table props paginated paginated Table should set rowsPerPage to first e
         100,
       ]
     }
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
 </div>
 `;
@@ -10143,10 +26051,9 @@ exports[`Table props paginated paginated=true should render PaginationToolbar 1`
 <div>
   <Memo(PaginationToolbar)
     count={7}
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={7}
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
   <styled__StyledTable>
     <TableHeader
@@ -10342,10 +26249,9 @@ exports[`Table props paginated paginated=true should render PaginationToolbar 1`
   </styled__StyledTable>
   <Memo(PaginationToolbar)
     count={7}
+    onPageChange={[Function]}
     page={0}
     rowsPerPage={7}
-    setPage={[Function]}
-    setRowsPerPage={[Function]}
   />
 </div>
 `;

--- a/src/table/src/components/__snapshots__/Table.test.js.snap
+++ b/src/table/src/components/__snapshots__/Table.test.js.snap
@@ -254,8 +254,10 @@ exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
     [MockFunction] {
       "calls": Array [
         Array [
-          "name",
-          true,
+          Object {
+            "column": "name",
+            "descending": true,
+          },
         ],
       ],
       "results": Array [

--- a/src/table/src/components/__snapshots__/Table.test.js.snap
+++ b/src/table/src/components/__snapshots__/Table.test.js.snap
@@ -6,7 +6,7 @@ exports[`Table handlePageChange should invoke onPageChange on pagination button 
     Array [
       Object {
         "column": undefined,
-        "descending": undefined,
+        "order": undefined,
         "page": 1,
         "rowsPerPage": 7,
         "start": 7,
@@ -281,7 +281,7 @@ exports[`Table handlePageChange should invoke onPageChange on pagination button 
         Array [
           Object {
             "column": undefined,
-            "descending": undefined,
+            "order": undefined,
             "page": 1,
             "rowsPerPage": 7,
             "start": 7,
@@ -4523,7 +4523,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
     Array [
       Object {
         "column": undefined,
-        "descending": undefined,
+        "order": undefined,
         "page": 0,
         "rowsPerPage": 20,
         "start": 0,
@@ -4804,7 +4804,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
         Array [
           Object {
             "column": undefined,
-            "descending": undefined,
+            "order": undefined,
             "page": 0,
             "rowsPerPage": 20,
             "start": 0,
@@ -16285,7 +16285,7 @@ exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
     Array [
       Object {
         "column": "name",
-        "descending": true,
+        "order": "desc",
         "page": 0,
         "rowsPerPage": 7,
         "start": 0,
@@ -16560,7 +16560,7 @@ exports[`Table handleSort should invoke onSort with property and isDesc 2`] = `
         Array [
           Object {
             "column": "name",
-            "descending": true,
+            "order": "desc",
             "page": 0,
             "rowsPerPage": 7,
             "start": 0,

--- a/src/table/src/components/__snapshots__/Table.test.js.snap
+++ b/src/table/src/components/__snapshots__/Table.test.js.snap
@@ -1,5 +1,4743 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Table handleSort should invoke onSort with property and isDesc 1`] = `
+.c5 {
+  background-color: #ffffff;
+  border-collapse: collapse;
+  border: none;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.c7 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+  width: 33%;
+}
+
+.c8 {
+  background-color: #f0f0f7;
+  cursor: pointer;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c9 {
+  background-color: #f0f0f7;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c11 {
+  background-color: inherit;
+  cursor: auto;
+  padding: 10px 10px;
+  text-align: left;
+  word-wrap: break-word;
+}
+
+.c6 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c6 td,
+.c6 th {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 200;
+}
+
+.c10 {
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdce7;
+}
+
+.c3 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  position: relative;
+  overflow: hidden;
+  min-width: 14px;
+}
+
+.c4 {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  opacity: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 18px;
+  outline: none;
+  padding: 10px 20px;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  transition: background-color 100ms ease-out,border-color 100ms ease-out,box-shadow 100ms ease-out;
+  white-space: nowrap;
+  background-color: transparent;
+  border-color: transparent;
+  color: #6124e2;
+}
+
+.c2:hover {
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.1);
+}
+
+.c2:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: rgba(0,0,0,0.15);
+}
+
+.c2:disabled {
+  cursor: not-allowed;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  border-color: transparent;
+  color: #b6bbc7;
+}
+
+.c2:focus-visible {
+  box-shadow: rgba(0,0,0,0.15) 0 0 0 2px;
+}
+
+.c1 {
+  color: #555e6f;
+  display: inline-block;
+  font-size: 14px;
+  font-stretch: normal;
+  font-style: normal;
+  font-weight: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  margin: 5px 5px 5px 0;
+  color: #8e929b;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+<Table
+  data={
+    Array [
+      Object {
+        "dob": "1942-11-30",
+        "id": "1",
+        "lastUpdated": "2019-09-01",
+        "manager": "Spongebob",
+        "name": "Eugene Krabs",
+      },
+      Object {
+        "dob": "",
+        "id": "2",
+        "lastUpdated": "2019-08-29",
+        "manager": "Smitty",
+        "name": "Squidward Tentacles",
+      },
+      Object {
+        "dob": "1987-11-17",
+        "id": "3",
+        "lastUpdated": "2019-07-30",
+        "manager": "Patrick",
+        "name": "Sandy Cheeks",
+      },
+      Object {
+        "dob": "1975-06-23",
+        "id": "4",
+        "lastUpdated": "2019-08-16",
+        "manager": "Patchy",
+        "name": "Larry the Lobster",
+      },
+      Object {
+        "dob": "1942-11-30",
+        "id": "5",
+        "lastUpdated": "2019-08-20",
+        "manager": "Spongebob",
+        "name": "Sheldon Plankton",
+      },
+      Object {
+        "dob": "",
+        "id": "6",
+        "lastUpdated": "2019-08-21",
+        "manager": "Spongebob",
+        "name": "Mrs. Puff",
+      },
+      Object {
+        "dob": "1678-04-20",
+        "id": "7",
+        "lastUpdated": "2019-06-21",
+        "manager": "Spongebob",
+        "name": "Flying Dutchman",
+      },
+    ]
+  }
+  headers={
+    Array [
+      Object {
+        "cellStyle": Object {
+          "width": "33%",
+        },
+        "key": "name",
+        "label": "Subject Name",
+      },
+      Object {
+        "key": "dob",
+        "label": "Date of Birth",
+      },
+      Object {
+        "key": "manager",
+        "label": "Manager",
+      },
+      Object {
+        "key": "lastUpdated",
+        "label": "Last Updated",
+      },
+      Object {
+        "key": "id",
+        "label": "ID",
+        "sortable": false,
+      },
+    ]
+  }
+  onSort={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "name",
+          true,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  paginated={true}
+>
+  <div>
+    <PaginationToolbar
+      count={7}
+      page={0}
+      rowsPerPage={7}
+      rowsPerPageOptions={Array []}
+      setPage={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+      setRowsPerPage={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 7 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+    <styled__StyledTable>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "styled__StyledTable-r3xwjs-0",
+              "isStatic": false,
+              "lastClassName": "c5",
+              "rules": Array [
+                "background-color:",
+                "#ffffff",
+                ";border-collapse:collapse;border:none;table-layout:fixed;width:100%;",
+              ],
+            },
+            "displayName": "styled__StyledTable",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "styled__StyledTable-r3xwjs-0",
+            "target": "table",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+      >
+        <table
+          className="c5"
+        >
+          <TableHeader
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c11",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            onSort={[Function]}
+            order={false}
+            sticky={true}
+          >
+            <thead>
+              <styled__StyledRow
+                sticky={true}
+              >
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__StyledRow-r3xwjs-3",
+                        "isStatic": false,
+                        "lastClassName": "c10",
+                        "rules": Array [
+                          "background-color:",
+                          "#ffffff",
+                          ";border-bottom:1px solid ",
+                          "#dcdce7",
+                          ";td,th{",
+                          [Function],
+                          "};",
+                        ],
+                      },
+                      "displayName": "styled__StyledRow",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                      "target": "tr",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  sticky={true}
+                >
+                  <tr
+                    className="c6"
+                  >
+                    <HeadCell
+                      cellStyle={
+                        Object {
+                          "width": "33%",
+                        }
+                      }
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="name"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={
+                          Object {
+                            "width": "33%",
+                          }
+                        }
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={
+                            Object {
+                              "width": "33%",
+                            }
+                          }
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c7"
+                            onClick={[Function]}
+                          >
+                            Subject Name
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="dob"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Date of Birth
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="manager"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Manager
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="lastUpdated"
+                      onClick={[Function]}
+                      order={false}
+                      sortable={true}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                        onClick={[Function]}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <th
+                            className="c8"
+                            onClick={[Function]}
+                          >
+                            Last Updated
+                            <span>
+                              <FontAwesomeIcon
+                                border={false}
+                                className=""
+                                fixedWidth={true}
+                                flip={null}
+                                icon={
+                                  Object {
+                                    "icon": Array [
+                                      320,
+                                      512,
+                                      Array [],
+                                      "f0dc",
+                                      Array [
+                                        "M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z",
+                                        "",
+                                      ],
+                                    ],
+                                    "iconName": "sort",
+                                    "prefix": "fad",
+                                  }
+                                }
+                                inverse={false}
+                                listItem={false}
+                                mask={null}
+                                pull={null}
+                                pulse={false}
+                                rotation={null}
+                                size={null}
+                                spin={false}
+                                swapOpacity={false}
+                                symbol={false}
+                                title=""
+                                transform={null}
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  className="svg-inline--fa fa-sort fa-w-10 fa-fw "
+                                  data-icon="sort"
+                                  data-prefix="fad"
+                                  focusable="false"
+                                  role="img"
+                                  style={Object {}}
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <g
+                                    className="fa-group"
+                                    style={Object {}}
+                                  >
+                                    <path
+                                      className="fa-secondary"
+                                      d="M279.05 288.05h-238c-21.4 0-32.07 25.95-17 41l119.1 119 .1.1a23.9 23.9 0 0 0 33.8-.1l119-119c15.1-15.05 4.4-41-17-41zm-238-64h238c21.4 0 32.1-25.9 17-41l-119-119a.94.94 0 0 0-.1-.1 23.9 23.9 0 0 0-33.8.1l-119.1 119c-15.05 15.1-4.4 41 17 41z"
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                    <path
+                                      className="fa-primary"
+                                      d=""
+                                      fill="currentColor"
+                                      style={Object {}}
+                                    />
+                                  </g>
+                                </svg>
+                              </FontAwesomeIcon>
+                            </span>
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                    <HeadCell
+                      cellStyle={Object {}}
+                      components={
+                        Object {
+                          "Body": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Cell": Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "styled__Cell-r3xwjs-2",
+                              "isStatic": false,
+                              "lastClassName": "c11",
+                              "rules": Array [
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Cell",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "styled__Cell-r3xwjs-2",
+                            "target": "td",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          },
+                          "HeadCell": [Function],
+                          "Header": [Function],
+                          "Pagination": Object {
+                            "$$typeof": Symbol(react.memo),
+                            "compare": null,
+                            "type": [Function],
+                          },
+                          "Row": [Function],
+                        }
+                      }
+                      key="id"
+                      order={false}
+                      sortable={false}
+                    >
+                      <Cell
+                        as="th"
+                        cellStyle={Object {}}
+                      >
+                        <StyledComponent
+                          as="th"
+                          cellStyle={Object {}}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <th
+                            className="c9"
+                          >
+                            ID
+                          </th>
+                        </StyledComponent>
+                      </Cell>
+                    </HeadCell>
+                  </tr>
+                </StyledComponent>
+              </styled__StyledRow>
+            </thead>
+          </TableHeader>
+          <TableBody
+            components={
+              Object {
+                "Body": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Cell": Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "styled__Cell-r3xwjs-2",
+                    "isStatic": false,
+                    "lastClassName": "c11",
+                    "rules": Array [
+                      [Function],
+                    ],
+                  },
+                  "displayName": "Cell",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "styled__Cell-r3xwjs-2",
+                  "target": "td",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                },
+                "HeadCell": [Function],
+                "Header": [Function],
+                "Pagination": Object {
+                  "$$typeof": Symbol(react.memo),
+                  "compare": null,
+                  "type": [Function],
+                },
+                "Row": [Function],
+              }
+            }
+            data={
+              Array [
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "1",
+                  "lastUpdated": "2019-09-01",
+                  "manager": "Spongebob",
+                  "name": "Eugene Krabs",
+                },
+                Object {
+                  "dob": "",
+                  "id": "2",
+                  "lastUpdated": "2019-08-29",
+                  "manager": "Smitty",
+                  "name": "Squidward Tentacles",
+                },
+                Object {
+                  "dob": "1987-11-17",
+                  "id": "3",
+                  "lastUpdated": "2019-07-30",
+                  "manager": "Patrick",
+                  "name": "Sandy Cheeks",
+                },
+                Object {
+                  "dob": "1975-06-23",
+                  "id": "4",
+                  "lastUpdated": "2019-08-16",
+                  "manager": "Patchy",
+                  "name": "Larry the Lobster",
+                },
+                Object {
+                  "dob": "1942-11-30",
+                  "id": "5",
+                  "lastUpdated": "2019-08-20",
+                  "manager": "Spongebob",
+                  "name": "Sheldon Plankton",
+                },
+                Object {
+                  "dob": "",
+                  "id": "6",
+                  "lastUpdated": "2019-08-21",
+                  "manager": "Spongebob",
+                  "name": "Mrs. Puff",
+                },
+                Object {
+                  "dob": "1678-04-20",
+                  "id": "7",
+                  "lastUpdated": "2019-06-21",
+                  "manager": "Spongebob",
+                  "name": "Flying Dutchman",
+                },
+              ]
+            }
+            exact={false}
+            headers={
+              Array [
+                Object {
+                  "cellStyle": Object {
+                    "width": "33%",
+                  },
+                  "key": "name",
+                  "label": "Subject Name",
+                },
+                Object {
+                  "key": "dob",
+                  "label": "Date of Birth",
+                },
+                Object {
+                  "key": "manager",
+                  "label": "Manager",
+                },
+                Object {
+                  "key": "lastUpdated",
+                  "label": "Last Updated",
+                },
+                Object {
+                  "key": "id",
+                  "label": "ID",
+                  "sortable": false,
+                },
+              ]
+            }
+            page={0}
+            rowsPerPage={7}
+          >
+            <tbody>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "1",
+                    "lastUpdated": "2019-09-01",
+                    "manager": "Spongebob",
+                    "name": "Eugene Krabs",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="1"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="1_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Eugene Krabs
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-09-01
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "2",
+                    "lastUpdated": "2019-08-29",
+                    "manager": "Smitty",
+                    "name": "Squidward Tentacles",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="2"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="2_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Squidward Tentacles
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Smitty
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-29
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1987-11-17",
+                    "id": "3",
+                    "lastUpdated": "2019-07-30",
+                    "manager": "Patrick",
+                    "name": "Sandy Cheeks",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="3"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="3_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sandy Cheeks
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1987-11-17
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patrick
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-07-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            3
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1975-06-23",
+                    "id": "4",
+                    "lastUpdated": "2019-08-16",
+                    "manager": "Patchy",
+                    "name": "Larry the Lobster",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="4"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="4_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Larry the Lobster
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1975-06-23
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patchy
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-16
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            4
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "5",
+                    "lastUpdated": "2019-08-20",
+                    "manager": "Spongebob",
+                    "name": "Sheldon Plankton",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="5"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="5_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sheldon Plankton
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            5
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "6",
+                    "lastUpdated": "2019-08-21",
+                    "manager": "Spongebob",
+                    "name": "Mrs. Puff",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="6"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="6_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Mrs. Puff
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            6
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1678-04-20",
+                    "id": "7",
+                    "lastUpdated": "2019-06-21",
+                    "manager": "Spongebob",
+                    "name": "Flying Dutchman",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="7"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="7_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Flying Dutchman
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1678-04-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-06-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            7
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+            </tbody>
+          </TableBody>
+        </table>
+      </StyledComponent>
+    </styled__StyledTable>
+    <PaginationToolbar
+      count={7}
+      page={0}
+      rowsPerPage={7}
+      rowsPerPageOptions={Array []}
+      setPage={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+      setRowsPerPage={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+            Array [
+              0,
+            ],
+            Array [
+              7,
+            ],
+            Array [
+              "desc",
+            ],
+            Array [
+              "name",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+    >
+      <styled__PaginationWrapper>
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "styled__PaginationWrapper-r3xwjs-1",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  "align-items:center;display:flex;justify-content:flex-end;width:100%;",
+                ],
+              },
+              "displayName": "styled__PaginationWrapper",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "styled__PaginationWrapper-r3xwjs-1",
+              "target": "div",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+        >
+          <div
+            className="c0"
+          >
+            <Label
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                >
+                  Rows per page
+                </label>
+              </StyledComponent>
+            </Label>
+            <Label
+              id="row-range"
+              subtle={true}
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Label-sc-130fyca-0",
+                      "isStatic": false,
+                      "lastClassName": "c1",
+                      "rules": Array [
+                        "color:",
+                        "#555e6f",
+                        ";display:inline-block;font-size:14px;font-stretch:normal;font-style:normal;font-weight:",
+                        [Function],
+                        ";letter-spacing:normal;margin:5px 5px 5px 0;visibility:",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                        [Function],
+                        ";",
+                      ],
+                    },
+                    "displayName": "Label",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Label-sc-130fyca-0",
+                    "target": "label",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                id="row-range"
+                subtle={true}
+              >
+                <label
+                  className="c1"
+                  id="row-range"
+                >
+                  1 - 7 of 7
+                </label>
+              </StyledComponent>
+            </Label>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f053",
+                        "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                      ],
+                      "iconName": "chevron-left",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f053",
+                                          "M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z",
+                                        ],
+                                        "iconName": "chevron-left",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-left fa-w-8 fa-fw "
+                                      data-icon="chevron-left"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M231.293 473.899l19.799-19.799c4.686-4.686 4.686-12.284 0-16.971L70.393 256 251.092 74.87c4.686-4.686 4.686-12.284 0-16.971L231.293 38.1c-4.686-4.686-12.284-4.686-16.971 0L4.908 247.515c-4.686 4.686-4.686 12.284 0 16.971L214.322 473.9c4.687 4.686 12.285 4.686 16.971-.001z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+            <IconButton
+              disabled={true}
+              icon={
+                <FontAwesomeIcon
+                  border={false}
+                  className=""
+                  fixedWidth={true}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        256,
+                        512,
+                        Array [],
+                        "f054",
+                        "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                      ],
+                      "iconName": "chevron-right",
+                      "prefix": "far",
+                    }
+                  }
+                  inverse={false}
+                  listItem={false}
+                  mask={null}
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size={null}
+                  spin={false}
+                  swapOpacity={false}
+                  symbol={false}
+                  title=""
+                  transform={null}
+                />
+              }
+              mode="subtle"
+              onClick={[Function]}
+            >
+              <Button
+                disabled={true}
+                fontColor=""
+                isLoading={false}
+                mode="subtle"
+                onClick={[Function]}
+                type="button"
+              >
+                <StyledButton
+                  disabled={true}
+                  fontColor=""
+                  mode="subtle"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <StyledComponent
+                    disabled={true}
+                    fontColor=""
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "StyledButton-sc-1etazn9-0",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "border-radius:3px;border-style:solid;border-width:1px;box-sizing:border-box;cursor:pointer;font-size:14px;line-height:18px;outline:none;padding:10px 20px;text-align:center;text-decoration:none;transition:background-color ",
+                            "100ms",
+                            " ease-out,border-color ",
+                            "100ms",
+                            " ease-out,box-shadow ",
+                            "100ms",
+                            " ease-out;width:",
+                            [Function],
+                            ";white-space:nowrap;",
+                            [Function],
+                            ";",
+                            [Function],
+                            ";:hover{cursor:pointer;text-decoration:none;",
+                            [Function],
+                            "};:active{text-decoration:none;",
+                            [Function],
+                            "};:disabled{cursor:not-allowed;text-decoration:none;",
+                            [Function],
+                            "};:focus-visible{",
+                            [Function],
+                            "}",
+                          ],
+                        },
+                        "displayName": "StyledButton",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "StyledButton-sc-1etazn9-0",
+                        "target": "button",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                    mode="subtle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="c2"
+                      disabled={true}
+                      mode="subtle"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <ContentWrapper>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ContentWrapper-sc-36hfub-0",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "align-self:center;display:inline-flex;flex-wrap:nowrap;max-width:100%;position:relative;overflow:hidden;min-width:14px;",
+                                ],
+                              },
+                              "displayName": "ContentWrapper",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ContentWrapper-sc-36hfub-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            className="c3"
+                          >
+                            <Content
+                              isLoading={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Content-sc-18psqsj-0",
+                                      "isStatic": false,
+                                      "lastClassName": "c4",
+                                      "rules": Array [
+                                        "flex:1 1 auto;opacity:",
+                                        [Function],
+                                        ";overflow:hidden;text-overflow:ellipsis;white-space:nowrap;",
+                                      ],
+                                    },
+                                    "displayName": "Content",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "Content-sc-18psqsj-0",
+                                    "target": "span",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                isLoading={false}
+                              >
+                                <span
+                                  className="c4"
+                                >
+                                  <FontAwesomeIcon
+                                    border={false}
+                                    className=""
+                                    fixedWidth={true}
+                                    flip={null}
+                                    icon={
+                                      Object {
+                                        "icon": Array [
+                                          256,
+                                          512,
+                                          Array [],
+                                          "f054",
+                                          "M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z",
+                                        ],
+                                        "iconName": "chevron-right",
+                                        "prefix": "far",
+                                      }
+                                    }
+                                    inverse={false}
+                                    listItem={false}
+                                    mask={null}
+                                    pull={null}
+                                    pulse={false}
+                                    rotation={null}
+                                    size={null}
+                                    spin={false}
+                                    swapOpacity={false}
+                                    symbol={false}
+                                    title=""
+                                    transform={null}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="svg-inline--fa fa-chevron-right fa-w-8 fa-fw "
+                                      data-icon="chevron-right"
+                                      data-prefix="far"
+                                      focusable="false"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 256 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M24.707 38.101L4.908 57.899c-4.686 4.686-4.686 12.284 0 16.971L185.607 256 4.908 437.13c-4.686 4.686-4.686 12.284 0 16.971L24.707 473.9c4.686 4.686 12.284 4.686 16.971 0l209.414-209.414c4.686-4.686 4.686-12.284 0-16.971L41.678 38.101c-4.687-4.687-12.285-4.687-16.971 0z"
+                                        fill="currentColor"
+                                        style={Object {}}
+                                      />
+                                    </svg>
+                                  </FontAwesomeIcon>
+                                </span>
+                              </StyledComponent>
+                            </Content>
+                          </span>
+                        </StyledComponent>
+                      </ContentWrapper>
+                    </button>
+                  </StyledComponent>
+                </StyledButton>
+              </Button>
+            </IconButton>
+          </div>
+        </StyledComponent>
+      </styled__PaginationWrapper>
+    </PaginationToolbar>
+  </div>
+</Table>
+`;
+
 exports[`Table handleSort should set order and orderBy when invoked 1`] = `
 .c5 {
   background-color: #ffffff;
@@ -56,7 +4794,6 @@ exports[`Table handleSort should set order and orderBy when invoked 1`] = `
   padding: 10px 10px;
   text-align: left;
   word-wrap: break-word;
-  height: 294px;
 }
 
 .c6 {
@@ -256,6 +4993,7 @@ exports[`Table handleSort should set order and orderBy when invoked 1`] = `
   <div>
     <PaginationToolbar
       count={7}
+      page={0}
       rowsPerPage={7}
       rowsPerPageOptions={Array []}
       setPage={
@@ -1863,6 +6601,7 @@ exports[`Table handleSort should set order and orderBy when invoked 1`] = `
                 },
               ]
             }
+            exact={false}
             headers={
               Array [
                 Object {
@@ -1891,96 +6630,2043 @@ exports[`Table handleSort should set order and orderBy when invoked 1`] = `
                 },
               ]
             }
+            page={0}
             rowsPerPage={7}
           >
             <tbody>
-              <styled__StyledRow
-                id="empty-row-filler"
-              >
-                <StyledComponent
-                  forwardedComponent={
-                    Object {
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
                       "$$typeof": Symbol(react.forward_ref),
                       "attrs": Array [],
                       "componentStyle": ComponentStyle {
-                        "componentId": "styled__StyledRow-r3xwjs-3",
+                        "componentId": "styled__Cell-r3xwjs-2",
                         "isStatic": false,
-                        "lastClassName": "c10",
+                        "lastClassName": "c11",
                         "rules": Array [
-                          "background-color:",
-                          "#ffffff",
-                          ";border-bottom:1px solid ",
-                          "#dcdce7",
-                          ";td,th{",
                           [Function],
-                          "};",
                         ],
                       },
-                      "displayName": "styled__StyledRow",
+                      "displayName": "Cell",
                       "foldedComponentIds": Array [],
                       "render": [Function],
-                      "styledComponentId": "styled__StyledRow-r3xwjs-3",
-                      "target": "tr",
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
                       "toString": [Function],
                       "warnTooManyClasses": [Function],
                       "withComponent": [Function],
-                    }
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
                   }
-                  forwardedRef={null}
-                  id="empty-row-filler"
-                >
-                  <tr
-                    className="c10"
-                    id="empty-row-filler"
-                  >
-                    <Cell
-                      cellStyle={
-                        Object {
-                          "height": "294px",
-                        }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "1",
+                    "lastUpdated": "2019-09-01",
+                    "manager": "Spongebob",
+                    "name": "Eugene Krabs",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="1"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
                       }
-                      colSpan={5}
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
                     >
-                      <StyledComponent
-                        cellStyle={
-                          Object {
-                            "height": "294px",
-                          }
-                        }
-                        colSpan={5}
-                        forwardedComponent={
-                          Object {
-                            "$$typeof": Symbol(react.forward_ref),
-                            "attrs": Array [],
-                            "componentStyle": ComponentStyle {
-                              "componentId": "styled__Cell-r3xwjs-2",
-                              "isStatic": false,
-                              "lastClassName": "c11",
-                              "rules": Array [
-                                [Function],
-                              ],
-                            },
-                            "displayName": "Cell",
-                            "foldedComponentIds": Array [],
-                            "render": [Function],
-                            "styledComponentId": "styled__Cell-r3xwjs-2",
-                            "target": "td",
-                            "toString": [Function],
-                            "warnTooManyClasses": [Function],
-                            "withComponent": [Function],
-                          }
-                        }
-                        forwardedRef={null}
+                      <Cell
+                        key="1_cell_name"
                       >
-                        <td
-                          className="c11"
-                          colSpan={5}
-                        />
-                      </StyledComponent>
-                    </Cell>
-                  </tr>
-                </StyledComponent>
-              </styled__StyledRow>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Eugene Krabs
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-09-01
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="1_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "2",
+                    "lastUpdated": "2019-08-29",
+                    "manager": "Smitty",
+                    "name": "Squidward Tentacles",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="2"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="2_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Squidward Tentacles
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Smitty
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-29
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="2_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1987-11-17",
+                    "id": "3",
+                    "lastUpdated": "2019-07-30",
+                    "manager": "Patrick",
+                    "name": "Sandy Cheeks",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="3"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="3_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sandy Cheeks
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1987-11-17
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patrick
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-07-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="3_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            3
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1975-06-23",
+                    "id": "4",
+                    "lastUpdated": "2019-08-16",
+                    "manager": "Patchy",
+                    "name": "Larry the Lobster",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="4"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="4_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Larry the Lobster
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1975-06-23
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Patchy
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-16
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="4_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            4
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1942-11-30",
+                    "id": "5",
+                    "lastUpdated": "2019-08-20",
+                    "manager": "Spongebob",
+                    "name": "Sheldon Plankton",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="5"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="5_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Sheldon Plankton
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1942-11-30
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="5_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            5
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "",
+                    "id": "6",
+                    "lastUpdated": "2019-08-21",
+                    "manager": "Spongebob",
+                    "name": "Mrs. Puff",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="6"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="6_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Mrs. Puff
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          />
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-08-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="6_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            6
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
+              <TableRow
+                components={
+                  Object {
+                    "Body": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Cell": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "styled__Cell-r3xwjs-2",
+                        "isStatic": false,
+                        "lastClassName": "c11",
+                        "rules": Array [
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Cell",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "styled__Cell-r3xwjs-2",
+                      "target": "td",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    },
+                    "HeadCell": [Function],
+                    "Header": [Function],
+                    "Pagination": Object {
+                      "$$typeof": Symbol(react.memo),
+                      "compare": null,
+                      "type": [Function],
+                    },
+                    "Row": [Function],
+                  }
+                }
+                data={
+                  Object {
+                    "dob": "1678-04-20",
+                    "id": "7",
+                    "lastUpdated": "2019-06-21",
+                    "manager": "Spongebob",
+                    "name": "Flying Dutchman",
+                  }
+                }
+                headers={
+                  Array [
+                    Object {
+                      "cellStyle": Object {
+                        "width": "33%",
+                      },
+                      "key": "name",
+                      "label": "Subject Name",
+                    },
+                    Object {
+                      "key": "dob",
+                      "label": "Date of Birth",
+                    },
+                    Object {
+                      "key": "manager",
+                      "label": "Manager",
+                    },
+                    Object {
+                      "key": "lastUpdated",
+                      "label": "Last Updated",
+                    },
+                    Object {
+                      "key": "id",
+                      "label": "ID",
+                      "sortable": false,
+                    },
+                  ]
+                }
+                key="7"
+              >
+                <styled__StyledRow>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "styled__StyledRow-r3xwjs-3",
+                          "isStatic": false,
+                          "lastClassName": "c10",
+                          "rules": Array [
+                            "background-color:",
+                            "#ffffff",
+                            ";border-bottom:1px solid ",
+                            "#dcdce7",
+                            ";td,th{",
+                            [Function],
+                            "};",
+                          ],
+                        },
+                        "displayName": "styled__StyledRow",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "styled__StyledRow-r3xwjs-3",
+                        "target": "tr",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
+                    }
+                    forwardedRef={null}
+                  >
+                    <tr
+                      className="c10"
+                    >
+                      <Cell
+                        key="7_cell_name"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Flying Dutchman
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_dob"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            1678-04-20
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_manager"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            Spongebob
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_lastUpdated"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            2019-06-21
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                      <Cell
+                        key="7_cell_id"
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "styled__Cell-r3xwjs-2",
+                                "isStatic": false,
+                                "lastClassName": "c11",
+                                "rules": Array [
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "Cell",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "styled__Cell-r3xwjs-2",
+                              "target": "td",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <td
+                            className="c11"
+                          >
+                            7
+                          </td>
+                        </StyledComponent>
+                      </Cell>
+                    </tr>
+                  </StyledComponent>
+                </styled__StyledRow>
+              </TableRow>
             </tbody>
           </TableBody>
         </table>
@@ -1988,6 +8674,7 @@ exports[`Table handleSort should set order and orderBy when invoked 1`] = `
     </styled__StyledTable>
     <PaginationToolbar
       count={7}
+      page={0}
       rowsPerPage={7}
       rowsPerPageOptions={Array []}
       setPage={
@@ -2851,6 +9538,7 @@ exports[`Table props paginated Table should set rowsPerPage to data.length when 
           },
         ]
       }
+      page={0}
       rowsPerPage={7}
     />
   </styled__StyledTable>
@@ -2860,7 +9548,7 @@ exports[`Table props paginated Table should set rowsPerPage to data.length when 
 exports[`Table props paginated paginated Table should set rowsPerPage to 5 by default 1`] = `
 <div>
   <Memo(PaginationToolbar)
-    count={0}
+    page={0}
     rowsPerPage={5}
     setPage={[Function]}
     setRowsPerPage={[Function]}
@@ -3000,11 +9688,12 @@ exports[`Table props paginated paginated Table should set rowsPerPage to 5 by de
           },
         ]
       }
+      page={0}
       rowsPerPage={5}
     />
   </styled__StyledTable>
   <Memo(PaginationToolbar)
-    count={0}
+    page={0}
     rowsPerPage={5}
     setPage={[Function]}
     setRowsPerPage={[Function]}
@@ -3016,6 +9705,7 @@ exports[`Table props paginated paginated Table should set rowsPerPage to data.le
 <div>
   <Memo(PaginationToolbar)
     count={7}
+    page={0}
     rowsPerPage={7}
     setPage={[Function]}
     setRowsPerPage={[Function]}
@@ -3208,11 +9898,13 @@ exports[`Table props paginated paginated Table should set rowsPerPage to data.le
           },
         ]
       }
+      page={0}
       rowsPerPage={7}
     />
   </styled__StyledTable>
   <Memo(PaginationToolbar)
     count={7}
+    page={0}
     rowsPerPage={7}
     setPage={[Function]}
     setRowsPerPage={[Function]}
@@ -3224,6 +9916,7 @@ exports[`Table props paginated paginated Table should set rowsPerPage to first e
 <div>
   <Memo(PaginationToolbar)
     count={7}
+    page={0}
     rowsPerPage={10}
     rowsPerPageOptions={
       Array [
@@ -3423,11 +10116,13 @@ exports[`Table props paginated paginated Table should set rowsPerPage to first e
           },
         ]
       }
+      page={0}
       rowsPerPage={10}
     />
   </styled__StyledTable>
   <Memo(PaginationToolbar)
     count={7}
+    page={0}
     rowsPerPage={10}
     rowsPerPageOptions={
       Array [
@@ -3446,6 +10141,7 @@ exports[`Table props paginated paginated=true should render PaginationToolbar 1`
 <div>
   <Memo(PaginationToolbar)
     count={7}
+    page={0}
     rowsPerPage={7}
     setPage={[Function]}
     setRowsPerPage={[Function]}
@@ -3638,11 +10334,13 @@ exports[`Table props paginated paginated=true should render PaginationToolbar 1`
           },
         ]
       }
+      page={0}
       rowsPerPage={7}
     />
   </styled__StyledTable>
   <Memo(PaginationToolbar)
     count={7}
+    page={0}
     rowsPerPage={7}
     setPage={[Function]}
     setRowsPerPage={[Function]}
@@ -3667,7 +10365,7 @@ exports[`Table render should render table first child 1`] = `
             "componentStyle": ComponentStyle {
               "componentId": "styled__Cell-r3xwjs-2",
               "isStatic": false,
-              "lastClassName": "dmTbmI",
+              "lastClassName": "bSxEEP",
               "rules": Array [
                 [Function],
               ],
@@ -3737,7 +10435,7 @@ exports[`Table render should render table first child 1`] = `
             "componentStyle": ComponentStyle {
               "componentId": "styled__Cell-r3xwjs-2",
               "isStatic": false,
-              "lastClassName": "dmTbmI",
+              "lastClassName": "bSxEEP",
               "rules": Array [
                 [Function],
               ],
@@ -3842,6 +10540,7 @@ exports[`Table render should render table first child 1`] = `
           },
         ]
       }
+      page={0}
       rowsPerPage={7}
     />
   </styled__StyledTable>

--- a/src/table/src/components/__snapshots__/TableHeader.test.js.snap
+++ b/src/table/src/components/__snapshots__/TableHeader.test.js.snap
@@ -1,6 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableHeader props onSort invoke onSort with property when HeadCell is clicked 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "name",
+      Object {
+        "target": "mock",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`TableHeader props onSort invoke onSort with property when HeadCell is clicked 2`] = `
 <thead>
   <styled__StyledRow
     sticky={true}

--- a/src/table/stories/index.stories.js
+++ b/src/table/stories/index.stories.js
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 
 import { Button } from '../../button';
 import {
@@ -22,6 +23,8 @@ import {
 const components = {
   Row: CustomRow
 };
+
+const rowsPerPageOptions = [5, 20, 50];
 
 storiesOf('Table', module)
   .add('Sortable', () => (
@@ -53,7 +56,7 @@ storiesOf('Table', module)
           <Table
               headers={TABLE_HEADERS}
               data={TABLE_DATA}
-              rowsPerPageOptions={[5, 20, 50]}
+              rowsPerPageOptions={rowsPerPageOptions}
               paginated />
         </CardSegment>
       </Card>
@@ -78,7 +81,7 @@ storiesOf('Table', module)
             components={components}
             headers={TABLE_HEADERS}
             data={TABLE_DATA}
-            rowsPerPageOptions={[5, 20, 50]}
+            rowsPerPageOptions={rowsPerPageOptions}
             paginated />
       </CardSegment>
     </Card>
@@ -101,15 +104,96 @@ storiesOf('Table', module)
       </Card>
     );
   })
-  .add('isLoading', () => (
-    <Card>
-      <CardSegment vertical>
-        <Table
-            components={components}
-            headers={TABLE_HEADERS}
-            isLoading
-            rowsPerPageOptions={[5, 20, 50]}
-            paginated />
-      </CardSegment>
-    </Card>
-  ));
+  .add('isLoading', () => {
+    const [data, setData] = useState([]);
+    const [isLoading, setLoading] = useState(true);
+
+    useEffect(() => {
+      const timeout = setTimeout(() => {
+        setLoading(false);
+        setData(TABLE_DATA);
+      }, 1000);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, [data]);
+
+    return (
+      <Card>
+        <CardSegment vertical>
+          <Table
+              components={components}
+              headers={TABLE_HEADERS}
+              data={data}
+              isLoading={isLoading}
+              rowsPerPageOptions={rowsPerPageOptions}
+              paginated />
+        </CardSegment>
+      </Card>
+    );
+  })
+  .add('Event handlers', () => {
+    const onPageChange = action('onPageChange');
+    const onSort = action('onSort');
+
+    return (
+      <Card>
+        <CardSegment vertical>
+          <Table
+              headers={TABLE_HEADERS}
+              data={TABLE_DATA}
+              rowsPerPageOptions={rowsPerPageOptions}
+              onPageChange={onPageChange}
+              onSort={onSort}
+              paginated />
+        </CardSegment>
+      </Card>
+    );
+  })
+  .add('Exact & totalRows', () => {
+    const [data, setData] = useState(TABLE_DATA.slice(0, 5));
+    const [isLoading, setLoading] = useState(true);
+
+    useEffect(() => {
+      const timeout = setTimeout(() => {
+        setLoading(false);
+      }, 1000);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, []);
+
+    const onPageChange = ({ start, rowsPerPage }) => {
+      setLoading(true);
+      setTimeout(() => {
+        setLoading(false);
+        setData(TABLE_DATA.slice(start, start + rowsPerPage));
+      }, 1000);
+    };
+
+    return (
+      <Card>
+        <CardSegment vertical>
+          <h1>exact + totalRows</h1>
+          <p>
+            {`
+              Use these properties if you only have the exact data to show per page, but still
+              want to suggest the ability to paginate. Use the onPageChange/onSort callbacks to
+              determine when to fetch fresh data.
+            `}
+          </p>
+          <Table
+              isLoading={isLoading}
+              headers={TABLE_HEADERS}
+              data={data}
+              exact
+              totalRows={TABLE_DATA.length}
+              rowsPerPageOptions={rowsPerPageOptions}
+              onPageChange={onPageChange}
+              paginated />
+        </CardSegment>
+      </Card>
+    );
+  });

--- a/src/utils/testing/MockUtils.js
+++ b/src/utils/testing/MockUtils.js
@@ -24,8 +24,18 @@ function genRealWordSelectOptions(text :string) {
   return stressOptions;
 }
 
+const MOCK_CLICK_EVENT = {
+  target: 'mock'
+};
+
+const MOCK_SELECT_EVENT = {
+  action: 'select-option'
+};
+
 export {
+  MOCK_CLICK_EVENT,
+  MOCK_SELECT_EVENT,
   genRandomString,
   genRealWordSelectOptions,
-  nope,
+  nope
 };


### PR DESCRIPTION
# Changes
The following props have been added to `Table`
- `exact :boolean` & `totalRows :number`
  - Use these properties if you only have the exact data to show per page, but still want to suggest the ability to paginate. Use the onPageChange/onSort callbacks to determine when to fetch fresh data.
- Add onPageChange
  - `
onPageChange ?:({
  column ?:string,
  order ?:'asc' | 'desc',
  page :number,
  rowsPerPage :number,
  start :number,
}) => void;
`
  - passed to `PaginationToolbar`

- Add onSort
  - `
onSort ?:({
  column ?:string,
  order ?:'asc' | 'desc',
  page :number,
  rowsPerPage :number,
  start :number,
}) => void;
`

![image](https://i.gyazo.com/cd01358300ce232935435c238c40838f.gif)