### PR TITLE
Feature/apps 1938 select icons

### DIFF
--- a/src/select/src/components/CheckboxSelect.js
+++ b/src/select/src/components/CheckboxSelect.js
@@ -1,14 +1,20 @@
 import React from 'react';
+
 import ReactSelect, { createFilter } from 'react-select';
 import { mergeDeep } from 'immutable';
 
+import DropdownIndicator from './styled/DropdownIndicator';
 import Option from './styled/CheckboxOption';
 import SelectController from './SelectController';
+import ValueContainer from './styled/ValueContainer';
+
 import { selectStyles } from '../../../style/select';
 
 export const defaultProps = {
   components: {
-    Option
+    DropdownIndicator,
+    Option,
+    ValueContainer,
   },
   closeMenuOnSelect: false,
   filterOption: createFilter({ ignoreAccents: false }),

--- a/src/select/src/components/SelectController.js
+++ b/src/select/src/components/SelectController.js
@@ -1,11 +1,13 @@
 // @flow
 import React, { Component } from 'react';
+import type { ComponentType, Node } from 'react';
+
 import isFunction from 'lodash/isFunction';
-import type { Node, ComponentType } from 'react';
 import type { IconDefinition } from '@fortawesome/react-fontawesome';
 
 import DropdownIndicator from './styled/DropdownIndicator';
 import SelectOption from './SelectOption';
+
 import type { ReactSelectEvent, ReactSelectOption, ReactSelectValue } from '../../types';
 
 type Props = {
@@ -71,13 +73,15 @@ class SelectController extends Component<Props> {
   composeProps = (props :Object) :Object => {
 
     const { icon } = this.props;
-    const components :Object = {
+    const defaultComponents :Object = {
       Option: SelectOption,
     };
 
     if (icon) {
-      components.DropdownIndicator = DropdownIndicator;
+      defaultComponents.DropdownIndicator = DropdownIndicator;
     }
+
+    const components = { ...defaultComponents, ...props.components };
 
     return { ...props, components };
   }

--- a/src/select/src/components/SelectController.js
+++ b/src/select/src/components/SelectController.js
@@ -1,17 +1,19 @@
 // @flow
 import React, { Component } from 'react';
-import type { ComponentType, Node } from 'react';
+import type { Node } from 'react';
 
 import isFunction from 'lodash/isFunction';
-import type { IconDefinition } from '@fortawesome/react-fontawesome';
 
 import DropdownIndicator from './styled/DropdownIndicator';
 import SelectOption from './SelectOption';
+import ValueContainer from './styled/ValueContainer';
 
 import type { ReactSelectEvent, ReactSelectOption, ReactSelectValue } from '../../types';
 
 type Props = {
-  icon ? :IconDefinition | ComponentType<any>;
+  dropdownIcon ? :Node;
+  hideDropdownIcon ? :boolean;
+  inputIcon ? :Node;
   isMulti :boolean;
   onChange :(value :any, event :ReactSelectEvent) => void;
   options :ReactSelectOption[] | any[];
@@ -21,9 +23,12 @@ type Props = {
 }
 
 class SelectController extends Component<Props> {
+
   static defaultProps = {
-    icon: undefined
-  }
+    dropdownIcon: undefined,
+    hideDropdownIcon: false,
+    inputIcon: undefined,
+  };
 
   handleChangeRawValues = (selectedOption :ReactSelectValue, event :ReactSelectEvent) => {
     const { onChange } = this.props;
@@ -72,14 +77,11 @@ class SelectController extends Component<Props> {
 
   composeProps = (props :Object) :Object => {
 
-    const { icon } = this.props;
     const defaultComponents :Object = {
       Option: SelectOption,
+      ValueContainer,
+      DropdownIndicator
     };
-
-    if (icon) {
-      defaultComponents.DropdownIndicator = DropdownIndicator;
-    }
 
     const components = { ...defaultComponents, ...props.components };
 

--- a/src/select/src/components/__snapshots__/CheckboxSelect.test.js.snap
+++ b/src/select/src/components/__snapshots__/CheckboxSelect.test.js.snap
@@ -3,19 +3,23 @@
 exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
 <CheckboxSelect>
   <SelectController
+    hideDropdownIcon={false}
     render={[Function]}
   >
     <StateManager
       closeMenuOnSelect={false}
       components={
         Object {
+          "DropdownIndicator": [Function],
           "Option": [Function],
+          "ValueContainer": [Function],
         }
       }
       defaultInputValue=""
       defaultMenuIsOpen={false}
       defaultValue={null}
       filterOption={[Function]}
+      hideDropdownIcon={false}
       hideSelectedOptions={false}
       isMulti={true}
       menuPlacement="auto"
@@ -44,7 +48,9 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
         closeMenuOnSelect={false}
         components={
           Object {
+            "DropdownIndicator": [Function],
             "Option": [Function],
+            "ValueContainer": [Function],
           }
         }
         controlShouldRenderValue={true}
@@ -53,6 +59,7 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
         formatGroupLabel={[Function]}
         getOptionLabel={[Function]}
         getOptionValue={[Function]}
+        hideDropdownIcon={false}
         hideSelectedOptions={false}
         inputValue=""
         isDisabled={false}
@@ -126,16 +133,20 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
               "closeMenuOnScroll": false,
               "closeMenuOnSelect": false,
               "components": Object {
+                "DropdownIndicator": [Function],
                 "Option": [Function],
+                "ValueContainer": [Function],
               },
               "controlShouldRenderValue": true,
+              "dropdownIcon": undefined,
               "escapeClearsValue": false,
               "filterOption": [Function],
               "formatGroupLabel": [Function],
               "getOptionLabel": [Function],
               "getOptionValue": [Function],
+              "hideDropdownIcon": false,
               "hideSelectedOptions": false,
-              "icon": undefined,
+              "inputIcon": undefined,
               "inputValue": "",
               "isDisabled": false,
               "isLoading": false,
@@ -261,16 +272,20 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                     "closeMenuOnScroll": false,
                     "closeMenuOnSelect": false,
                     "components": Object {
+                      "DropdownIndicator": [Function],
                       "Option": [Function],
+                      "ValueContainer": [Function],
                     },
                     "controlShouldRenderValue": true,
+                    "dropdownIcon": undefined,
                     "escapeClearsValue": false,
                     "filterOption": [Function],
                     "formatGroupLabel": [Function],
                     "getOptionLabel": [Function],
                     "getOptionValue": [Function],
+                    "hideDropdownIcon": false,
                     "hideSelectedOptions": false,
-                    "icon": undefined,
+                    "inputIcon": undefined,
                     "inputValue": "",
                     "isDisabled": false,
                     "isLoading": false,
@@ -397,6 +412,7 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                       getStyles={[Function]}
                       getValue={[Function]}
                       hasValue={false}
+                      inputIcon={null}
                       isDisabled={false}
                       isMulti={true}
                       isRtl={false}
@@ -410,16 +426,20 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                           "closeMenuOnScroll": false,
                           "closeMenuOnSelect": false,
                           "components": Object {
+                            "DropdownIndicator": [Function],
                             "Option": [Function],
+                            "ValueContainer": [Function],
                           },
                           "controlShouldRenderValue": true,
+                          "dropdownIcon": undefined,
                           "escapeClearsValue": false,
                           "filterOption": [Function],
                           "formatGroupLabel": [Function],
                           "getOptionLabel": [Function],
                           "getOptionValue": [Function],
+                          "hideDropdownIcon": false,
                           "hideSelectedOptions": false,
-                          "icon": undefined,
+                          "inputIcon": undefined,
                           "inputValue": "",
                           "isDisabled": false,
                           "isLoading": false,
@@ -496,373 +516,492 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                         }
                       }
                     >
-                      <EmotionCssPropInternal
-                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                        className=""
-                        css={
+                      <ValueContainer
+                        clearValue={[Function]}
+                        cx={[Function]}
+                        getStyles={[Function]}
+                        getValue={[Function]}
+                        hasValue={false}
+                        inputIcon={null}
+                        isDisabled={false}
+                        isMulti={true}
+                        isRtl={false}
+                        options={Array []}
+                        selectOption={[Function]}
+                        selectProps={
                           Object {
-                            "WebkitOverflowScrolling": "touch",
-                            "alignItems": "center",
-                            "boxSizing": "border-box",
-                            "display": "flex",
-                            "flex": 1,
-                            "flexWrap": "wrap",
-                            "overflow": "hidden",
-                            "padding": "0 10px",
-                            "position": "relative",
+                            "backspaceRemovesValue": true,
+                            "blurInputOnSelect": true,
+                            "captureMenuScroll": false,
+                            "closeMenuOnScroll": false,
+                            "closeMenuOnSelect": false,
+                            "components": Object {
+                              "DropdownIndicator": [Function],
+                              "Option": [Function],
+                              "ValueContainer": [Function],
+                            },
+                            "controlShouldRenderValue": true,
+                            "dropdownIcon": undefined,
+                            "escapeClearsValue": false,
+                            "filterOption": [Function],
+                            "formatGroupLabel": [Function],
+                            "getOptionLabel": [Function],
+                            "getOptionValue": [Function],
+                            "hideDropdownIcon": false,
+                            "hideSelectedOptions": false,
+                            "inputIcon": undefined,
+                            "inputValue": "",
+                            "isDisabled": false,
+                            "isLoading": false,
+                            "isMulti": true,
+                            "isOptionDisabled": [Function],
+                            "isRtl": false,
+                            "isSearchable": true,
+                            "loadingMessage": [Function],
+                            "maxMenuHeight": 300,
+                            "menuIsOpen": false,
+                            "menuPlacement": "auto",
+                            "menuPosition": "absolute",
+                            "menuShouldBlockScroll": false,
+                            "menuShouldScrollIntoView": true,
+                            "minMenuHeight": 140,
+                            "noOptionsMessage": [Function],
+                            "onChange": [Function],
+                            "onInputChange": [Function],
+                            "onMenuClose": [Function],
+                            "onMenuOpen": [Function],
+                            "openMenuOnClick": true,
+                            "openMenuOnFocus": false,
+                            "options": Array [],
+                            "pageSize": 5,
+                            "placeholder": "Select...",
+                            "screenReaderStatus": [Function],
+                            "styles": Object {
+                              "clearIndicator": [Function],
+                              "container": [Function],
+                              "control": [Function],
+                              "dropdownIndicator": [Function],
+                              "indicatorSeparator": [Function],
+                              "indicatorsContainer": [Function],
+                              "menu": [Function],
+                              "menuList": [Function],
+                              "menuPortal": [Function],
+                              "option": [Function],
+                              "singleValue": [Function],
+                              "valueContainer": [Function],
+                            },
+                            "tabIndex": "0",
+                            "tabSelectsValue": true,
+                            "value": null,
+                          }
+                        }
+                        setValue={[Function]}
+                        theme={
+                          Object {
+                            "borderRadius": 4,
+                            "colors": Object {
+                              "danger": "#DE350B",
+                              "dangerLight": "#FFBDAD",
+                              "neutral0": "hsl(0, 0%, 100%)",
+                              "neutral10": "hsl(0, 0%, 90%)",
+                              "neutral20": "hsl(0, 0%, 80%)",
+                              "neutral30": "hsl(0, 0%, 70%)",
+                              "neutral40": "hsl(0, 0%, 60%)",
+                              "neutral5": "hsl(0, 0%, 95%)",
+                              "neutral50": "hsl(0, 0%, 50%)",
+                              "neutral60": "hsl(0, 0%, 40%)",
+                              "neutral70": "hsl(0, 0%, 30%)",
+                              "neutral80": "hsl(0, 0%, 20%)",
+                              "neutral90": "hsl(0, 0%, 10%)",
+                              "primary": "#2684FF",
+                              "primary25": "#DEEBFF",
+                              "primary50": "#B2D4FF",
+                              "primary75": "#4C9AFF",
+                            },
+                            "spacing": Object {
+                              "baseUnit": 4,
+                              "controlHeight": 38,
+                              "menuGutter": 8,
+                            },
                           }
                         }
                       >
-                        <div
-                          className=" css-1gbz4ua"
+                        <EmotionCssPropInternal
+                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                          className=""
+                          css={
+                            Object {
+                              "WebkitOverflowScrolling": "touch",
+                              "alignItems": "center",
+                              "boxSizing": "border-box",
+                              "display": "flex",
+                              "flex": 1,
+                              "flexWrap": "wrap",
+                              "overflow": "hidden",
+                              "padding": "0 10px",
+                              "position": "relative",
+                            }
+                          }
                         >
-                          <Placeholder
-                            clearValue={[Function]}
-                            cx={[Function]}
-                            getStyles={[Function]}
-                            getValue={[Function]}
-                            hasValue={false}
-                            isDisabled={false}
-                            isFocused={false}
-                            isMulti={true}
-                            isRtl={false}
-                            key="placeholder"
-                            options={Array []}
-                            selectOption={[Function]}
-                            selectProps={
-                              Object {
-                                "backspaceRemovesValue": true,
-                                "blurInputOnSelect": true,
-                                "captureMenuScroll": false,
-                                "closeMenuOnScroll": false,
-                                "closeMenuOnSelect": false,
-                                "components": Object {
-                                  "Option": [Function],
-                                },
-                                "controlShouldRenderValue": true,
-                                "escapeClearsValue": false,
-                                "filterOption": [Function],
-                                "formatGroupLabel": [Function],
-                                "getOptionLabel": [Function],
-                                "getOptionValue": [Function],
-                                "hideSelectedOptions": false,
-                                "icon": undefined,
-                                "inputValue": "",
-                                "isDisabled": false,
-                                "isLoading": false,
-                                "isMulti": true,
-                                "isOptionDisabled": [Function],
-                                "isRtl": false,
-                                "isSearchable": true,
-                                "loadingMessage": [Function],
-                                "maxMenuHeight": 300,
-                                "menuIsOpen": false,
-                                "menuPlacement": "auto",
-                                "menuPosition": "absolute",
-                                "menuShouldBlockScroll": false,
-                                "menuShouldScrollIntoView": true,
-                                "minMenuHeight": 140,
-                                "noOptionsMessage": [Function],
-                                "onChange": [Function],
-                                "onInputChange": [Function],
-                                "onMenuClose": [Function],
-                                "onMenuOpen": [Function],
-                                "openMenuOnClick": true,
-                                "openMenuOnFocus": false,
-                                "options": Array [],
-                                "pageSize": 5,
-                                "placeholder": "Select...",
-                                "screenReaderStatus": [Function],
-                                "styles": Object {
-                                  "clearIndicator": [Function],
-                                  "container": [Function],
-                                  "control": [Function],
-                                  "dropdownIndicator": [Function],
-                                  "indicatorSeparator": [Function],
-                                  "indicatorsContainer": [Function],
-                                  "menu": [Function],
-                                  "menuList": [Function],
-                                  "menuPortal": [Function],
-                                  "option": [Function],
-                                  "singleValue": [Function],
-                                  "valueContainer": [Function],
-                                },
-                                "tabIndex": "0",
-                                "tabSelectsValue": true,
-                                "value": null,
-                              }
-                            }
-                            setValue={[Function]}
-                            theme={
-                              Object {
-                                "borderRadius": 4,
-                                "colors": Object {
-                                  "danger": "#DE350B",
-                                  "dangerLight": "#FFBDAD",
-                                  "neutral0": "hsl(0, 0%, 100%)",
-                                  "neutral10": "hsl(0, 0%, 90%)",
-                                  "neutral20": "hsl(0, 0%, 80%)",
-                                  "neutral30": "hsl(0, 0%, 70%)",
-                                  "neutral40": "hsl(0, 0%, 60%)",
-                                  "neutral5": "hsl(0, 0%, 95%)",
-                                  "neutral50": "hsl(0, 0%, 50%)",
-                                  "neutral60": "hsl(0, 0%, 40%)",
-                                  "neutral70": "hsl(0, 0%, 30%)",
-                                  "neutral80": "hsl(0, 0%, 20%)",
-                                  "neutral90": "hsl(0, 0%, 10%)",
-                                  "primary": "#2684FF",
-                                  "primary25": "#DEEBFF",
-                                  "primary50": "#B2D4FF",
-                                  "primary75": "#4C9AFF",
-                                },
-                                "spacing": Object {
-                                  "baseUnit": 4,
-                                  "controlHeight": 38,
-                                  "menuGutter": 8,
-                                },
-                              }
-                            }
+                          <div
+                            className=" css-1gbz4ua"
                           >
-                            <EmotionCssPropInternal
-                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Placeholder"
-                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                              className=""
-                              css={
+                            <Placeholder
+                              clearValue={[Function]}
+                              cx={[Function]}
+                              getStyles={[Function]}
+                              getValue={[Function]}
+                              hasValue={false}
+                              isDisabled={false}
+                              isFocused={false}
+                              isMulti={true}
+                              isRtl={false}
+                              key="placeholder"
+                              options={Array []}
+                              selectOption={[Function]}
+                              selectProps={
                                 Object {
-                                  "boxSizing": "border-box",
-                                  "color": "hsl(0, 0%, 50%)",
-                                  "label": "placeholder",
-                                  "marginLeft": 2,
-                                  "marginRight": 2,
-                                  "position": "absolute",
-                                  "top": "50%",
-                                  "transform": "translateY(-50%)",
+                                  "backspaceRemovesValue": true,
+                                  "blurInputOnSelect": true,
+                                  "captureMenuScroll": false,
+                                  "closeMenuOnScroll": false,
+                                  "closeMenuOnSelect": false,
+                                  "components": Object {
+                                    "DropdownIndicator": [Function],
+                                    "Option": [Function],
+                                    "ValueContainer": [Function],
+                                  },
+                                  "controlShouldRenderValue": true,
+                                  "dropdownIcon": undefined,
+                                  "escapeClearsValue": false,
+                                  "filterOption": [Function],
+                                  "formatGroupLabel": [Function],
+                                  "getOptionLabel": [Function],
+                                  "getOptionValue": [Function],
+                                  "hideDropdownIcon": false,
+                                  "hideSelectedOptions": false,
+                                  "inputIcon": undefined,
+                                  "inputValue": "",
+                                  "isDisabled": false,
+                                  "isLoading": false,
+                                  "isMulti": true,
+                                  "isOptionDisabled": [Function],
+                                  "isRtl": false,
+                                  "isSearchable": true,
+                                  "loadingMessage": [Function],
+                                  "maxMenuHeight": 300,
+                                  "menuIsOpen": false,
+                                  "menuPlacement": "auto",
+                                  "menuPosition": "absolute",
+                                  "menuShouldBlockScroll": false,
+                                  "menuShouldScrollIntoView": true,
+                                  "minMenuHeight": 140,
+                                  "noOptionsMessage": [Function],
+                                  "onChange": [Function],
+                                  "onInputChange": [Function],
+                                  "onMenuClose": [Function],
+                                  "onMenuOpen": [Function],
+                                  "openMenuOnClick": true,
+                                  "openMenuOnFocus": false,
+                                  "options": Array [],
+                                  "pageSize": 5,
+                                  "placeholder": "Select...",
+                                  "screenReaderStatus": [Function],
+                                  "styles": Object {
+                                    "clearIndicator": [Function],
+                                    "container": [Function],
+                                    "control": [Function],
+                                    "dropdownIndicator": [Function],
+                                    "indicatorSeparator": [Function],
+                                    "indicatorsContainer": [Function],
+                                    "menu": [Function],
+                                    "menuList": [Function],
+                                    "menuPortal": [Function],
+                                    "option": [Function],
+                                    "singleValue": [Function],
+                                    "valueContainer": [Function],
+                                  },
+                                  "tabIndex": "0",
+                                  "tabSelectsValue": true,
+                                  "value": null,
+                                }
+                              }
+                              setValue={[Function]}
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(0, 0%, 100%)",
+                                    "neutral10": "hsl(0, 0%, 90%)",
+                                    "neutral20": "hsl(0, 0%, 80%)",
+                                    "neutral30": "hsl(0, 0%, 70%)",
+                                    "neutral40": "hsl(0, 0%, 60%)",
+                                    "neutral5": "hsl(0, 0%, 95%)",
+                                    "neutral50": "hsl(0, 0%, 50%)",
+                                    "neutral60": "hsl(0, 0%, 40%)",
+                                    "neutral70": "hsl(0, 0%, 30%)",
+                                    "neutral80": "hsl(0, 0%, 20%)",
+                                    "neutral90": "hsl(0, 0%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
                                 }
                               }
                             >
-                              <div
-                                className=" css-1wa3eu0-placeholder"
-                              >
-                                Select...
-                              </div>
-                            </EmotionCssPropInternal>
-                          </Placeholder>
-                          <Input
-                            aria-autocomplete="list"
-                            autoCapitalize="none"
-                            autoComplete="off"
-                            autoCorrect="off"
-                            cx={[Function]}
-                            getStyles={[Function]}
-                            id="react-select-2-input"
-                            innerRef={[Function]}
-                            isDisabled={false}
-                            isHidden={false}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            selectProps={
-                              Object {
-                                "backspaceRemovesValue": true,
-                                "blurInputOnSelect": true,
-                                "captureMenuScroll": false,
-                                "closeMenuOnScroll": false,
-                                "closeMenuOnSelect": false,
-                                "components": Object {
-                                  "Option": [Function],
-                                },
-                                "controlShouldRenderValue": true,
-                                "escapeClearsValue": false,
-                                "filterOption": [Function],
-                                "formatGroupLabel": [Function],
-                                "getOptionLabel": [Function],
-                                "getOptionValue": [Function],
-                                "hideSelectedOptions": false,
-                                "icon": undefined,
-                                "inputValue": "",
-                                "isDisabled": false,
-                                "isLoading": false,
-                                "isMulti": true,
-                                "isOptionDisabled": [Function],
-                                "isRtl": false,
-                                "isSearchable": true,
-                                "loadingMessage": [Function],
-                                "maxMenuHeight": 300,
-                                "menuIsOpen": false,
-                                "menuPlacement": "auto",
-                                "menuPosition": "absolute",
-                                "menuShouldBlockScroll": false,
-                                "menuShouldScrollIntoView": true,
-                                "minMenuHeight": 140,
-                                "noOptionsMessage": [Function],
-                                "onChange": [Function],
-                                "onInputChange": [Function],
-                                "onMenuClose": [Function],
-                                "onMenuOpen": [Function],
-                                "openMenuOnClick": true,
-                                "openMenuOnFocus": false,
-                                "options": Array [],
-                                "pageSize": 5,
-                                "placeholder": "Select...",
-                                "screenReaderStatus": [Function],
-                                "styles": Object {
-                                  "clearIndicator": [Function],
-                                  "container": [Function],
-                                  "control": [Function],
-                                  "dropdownIndicator": [Function],
-                                  "indicatorSeparator": [Function],
-                                  "indicatorsContainer": [Function],
-                                  "menu": [Function],
-                                  "menuList": [Function],
-                                  "menuPortal": [Function],
-                                  "option": [Function],
-                                  "singleValue": [Function],
-                                  "valueContainer": [Function],
-                                },
-                                "tabIndex": "0",
-                                "tabSelectsValue": true,
-                                "value": null,
-                              }
-                            }
-                            spellCheck="false"
-                            tabIndex="0"
-                            theme={
-                              Object {
-                                "borderRadius": 4,
-                                "colors": Object {
-                                  "danger": "#DE350B",
-                                  "dangerLight": "#FFBDAD",
-                                  "neutral0": "hsl(0, 0%, 100%)",
-                                  "neutral10": "hsl(0, 0%, 90%)",
-                                  "neutral20": "hsl(0, 0%, 80%)",
-                                  "neutral30": "hsl(0, 0%, 70%)",
-                                  "neutral40": "hsl(0, 0%, 60%)",
-                                  "neutral5": "hsl(0, 0%, 95%)",
-                                  "neutral50": "hsl(0, 0%, 50%)",
-                                  "neutral60": "hsl(0, 0%, 40%)",
-                                  "neutral70": "hsl(0, 0%, 30%)",
-                                  "neutral80": "hsl(0, 0%, 20%)",
-                                  "neutral90": "hsl(0, 0%, 10%)",
-                                  "primary": "#2684FF",
-                                  "primary25": "#DEEBFF",
-                                  "primary50": "#B2D4FF",
-                                  "primary75": "#4C9AFF",
-                                },
-                                "spacing": Object {
-                                  "baseUnit": 4,
-                                  "controlHeight": 38,
-                                  "menuGutter": 8,
-                                },
-                              }
-                            }
-                            type="text"
-                            value=""
-                          >
-                            <EmotionCssPropInternal
-                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
-                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                              css={
-                                Object {
-                                  "boxSizing": "border-box",
-                                  "color": "hsl(0, 0%, 20%)",
-                                  "margin": 2,
-                                  "paddingBottom": 2,
-                                  "paddingTop": 2,
-                                  "visibility": "visible",
-                                }
-                              }
-                            >
-                              <div
-                                className="css-b8ldur-Input"
-                              >
-                                <AutosizeInput
-                                  aria-autocomplete="list"
-                                  autoCapitalize="none"
-                                  autoComplete="off"
-                                  autoCorrect="off"
-                                  className=""
-                                  disabled={false}
-                                  id="react-select-2-input"
-                                  injectStyles={true}
-                                  inputRef={[Function]}
-                                  inputStyle={
-                                    Object {
-                                      "background": 0,
-                                      "border": 0,
-                                      "color": "inherit",
-                                      "fontSize": "inherit",
-                                      "label": "input",
-                                      "opacity": 1,
-                                      "outline": 0,
-                                      "padding": 0,
-                                    }
+                              <EmotionCssPropInternal
+                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Placeholder"
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                className=""
+                                css={
+                                  Object {
+                                    "boxSizing": "border-box",
+                                    "color": "hsl(0, 0%, 50%)",
+                                    "label": "placeholder",
+                                    "marginLeft": 2,
+                                    "marginRight": 2,
+                                    "position": "absolute",
+                                    "top": "50%",
+                                    "transform": "translateY(-50%)",
                                   }
-                                  minWidth={1}
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  spellCheck="false"
-                                  tabIndex="0"
-                                  type="text"
-                                  value=""
+                                }
+                              >
+                                <div
+                                  className=" css-1wa3eu0-placeholder"
                                 >
-                                  <div
+                                  Select...
+                                </div>
+                              </EmotionCssPropInternal>
+                            </Placeholder>
+                            <Input
+                              aria-autocomplete="list"
+                              autoCapitalize="none"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              cx={[Function]}
+                              getStyles={[Function]}
+                              id="react-select-2-input"
+                              innerRef={[Function]}
+                              isDisabled={false}
+                              isHidden={false}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              selectProps={
+                                Object {
+                                  "backspaceRemovesValue": true,
+                                  "blurInputOnSelect": true,
+                                  "captureMenuScroll": false,
+                                  "closeMenuOnScroll": false,
+                                  "closeMenuOnSelect": false,
+                                  "components": Object {
+                                    "DropdownIndicator": [Function],
+                                    "Option": [Function],
+                                    "ValueContainer": [Function],
+                                  },
+                                  "controlShouldRenderValue": true,
+                                  "dropdownIcon": undefined,
+                                  "escapeClearsValue": false,
+                                  "filterOption": [Function],
+                                  "formatGroupLabel": [Function],
+                                  "getOptionLabel": [Function],
+                                  "getOptionValue": [Function],
+                                  "hideDropdownIcon": false,
+                                  "hideSelectedOptions": false,
+                                  "inputIcon": undefined,
+                                  "inputValue": "",
+                                  "isDisabled": false,
+                                  "isLoading": false,
+                                  "isMulti": true,
+                                  "isOptionDisabled": [Function],
+                                  "isRtl": false,
+                                  "isSearchable": true,
+                                  "loadingMessage": [Function],
+                                  "maxMenuHeight": 300,
+                                  "menuIsOpen": false,
+                                  "menuPlacement": "auto",
+                                  "menuPosition": "absolute",
+                                  "menuShouldBlockScroll": false,
+                                  "menuShouldScrollIntoView": true,
+                                  "minMenuHeight": 140,
+                                  "noOptionsMessage": [Function],
+                                  "onChange": [Function],
+                                  "onInputChange": [Function],
+                                  "onMenuClose": [Function],
+                                  "onMenuOpen": [Function],
+                                  "openMenuOnClick": true,
+                                  "openMenuOnFocus": false,
+                                  "options": Array [],
+                                  "pageSize": 5,
+                                  "placeholder": "Select...",
+                                  "screenReaderStatus": [Function],
+                                  "styles": Object {
+                                    "clearIndicator": [Function],
+                                    "container": [Function],
+                                    "control": [Function],
+                                    "dropdownIndicator": [Function],
+                                    "indicatorSeparator": [Function],
+                                    "indicatorsContainer": [Function],
+                                    "menu": [Function],
+                                    "menuList": [Function],
+                                    "menuPortal": [Function],
+                                    "option": [Function],
+                                    "singleValue": [Function],
+                                    "valueContainer": [Function],
+                                  },
+                                  "tabIndex": "0",
+                                  "tabSelectsValue": true,
+                                  "value": null,
+                                }
+                              }
+                              spellCheck="false"
+                              tabIndex="0"
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(0, 0%, 100%)",
+                                    "neutral10": "hsl(0, 0%, 90%)",
+                                    "neutral20": "hsl(0, 0%, 80%)",
+                                    "neutral30": "hsl(0, 0%, 70%)",
+                                    "neutral40": "hsl(0, 0%, 60%)",
+                                    "neutral5": "hsl(0, 0%, 95%)",
+                                    "neutral50": "hsl(0, 0%, 50%)",
+                                    "neutral60": "hsl(0, 0%, 40%)",
+                                    "neutral70": "hsl(0, 0%, 30%)",
+                                    "neutral80": "hsl(0, 0%, 20%)",
+                                    "neutral90": "hsl(0, 0%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
+                                }
+                              }
+                              type="text"
+                              value=""
+                            >
+                              <EmotionCssPropInternal
+                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                css={
+                                  Object {
+                                    "boxSizing": "border-box",
+                                    "color": "hsl(0, 0%, 20%)",
+                                    "margin": 2,
+                                    "paddingBottom": 2,
+                                    "paddingTop": 2,
+                                    "visibility": "visible",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="css-b8ldur-Input"
+                                >
+                                  <AutosizeInput
+                                    aria-autocomplete="list"
+                                    autoCapitalize="none"
+                                    autoComplete="off"
+                                    autoCorrect="off"
                                     className=""
-                                    style={
+                                    disabled={false}
+                                    id="react-select-2-input"
+                                    injectStyles={true}
+                                    inputRef={[Function]}
+                                    inputStyle={
                                       Object {
-                                        "display": "inline-block",
+                                        "background": 0,
+                                        "border": 0,
+                                        "color": "inherit",
+                                        "fontSize": "inherit",
+                                        "label": "input",
+                                        "opacity": 1,
+                                        "outline": 0,
+                                        "padding": 0,
                                       }
                                     }
+                                    minWidth={1}
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    spellCheck="false"
+                                    tabIndex="0"
+                                    type="text"
+                                    value=""
                                   >
-                                    <input
-                                      aria-autocomplete="list"
-                                      autoCapitalize="none"
-                                      autoComplete="off"
-                                      autoCorrect="off"
-                                      disabled={false}
-                                      id="react-select-2-input"
-                                      onBlur={[Function]}
-                                      onChange={[Function]}
-                                      onFocus={[Function]}
-                                      spellCheck="false"
-                                      style={
-                                        Object {
-                                          "background": 0,
-                                          "border": 0,
-                                          "boxSizing": "content-box",
-                                          "color": "inherit",
-                                          "fontSize": "inherit",
-                                          "label": "input",
-                                          "opacity": 1,
-                                          "outline": 0,
-                                          "padding": 0,
-                                          "width": "2px",
-                                        }
-                                      }
-                                      tabIndex="0"
-                                      type="text"
-                                      value=""
-                                    />
                                     <div
+                                      className=""
                                       style={
                                         Object {
-                                          "height": 0,
-                                          "left": 0,
-                                          "overflow": "scroll",
-                                          "position": "absolute",
-                                          "top": 0,
-                                          "visibility": "hidden",
-                                          "whiteSpace": "pre",
+                                          "display": "inline-block",
                                         }
                                       }
-                                    />
-                                  </div>
-                                </AutosizeInput>
-                              </div>
-                            </EmotionCssPropInternal>
-                          </Input>
-                        </div>
-                      </EmotionCssPropInternal>
+                                    >
+                                      <input
+                                        aria-autocomplete="list"
+                                        autoCapitalize="none"
+                                        autoComplete="off"
+                                        autoCorrect="off"
+                                        disabled={false}
+                                        id="react-select-2-input"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        spellCheck="false"
+                                        style={
+                                          Object {
+                                            "background": 0,
+                                            "border": 0,
+                                            "boxSizing": "content-box",
+                                            "color": "inherit",
+                                            "fontSize": "inherit",
+                                            "label": "input",
+                                            "opacity": 1,
+                                            "outline": 0,
+                                            "padding": 0,
+                                            "width": "2px",
+                                          }
+                                        }
+                                        tabIndex="0"
+                                        type="text"
+                                        value=""
+                                      />
+                                      <div
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "left": 0,
+                                            "overflow": "scroll",
+                                            "position": "absolute",
+                                            "top": 0,
+                                            "visibility": "hidden",
+                                            "whiteSpace": "pre",
+                                          }
+                                        }
+                                      />
+                                    </div>
+                                  </AutosizeInput>
+                                </div>
+                              </EmotionCssPropInternal>
+                            </Input>
+                          </div>
+                        </EmotionCssPropInternal>
+                      </ValueContainer>
                     </ValueContainer>
                     <IndicatorsContainer
                       clearValue={[Function]}
@@ -883,16 +1022,20 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                           "closeMenuOnScroll": false,
                           "closeMenuOnSelect": false,
                           "components": Object {
+                            "DropdownIndicator": [Function],
                             "Option": [Function],
+                            "ValueContainer": [Function],
                           },
                           "controlShouldRenderValue": true,
+                          "dropdownIcon": undefined,
                           "escapeClearsValue": false,
                           "filterOption": [Function],
                           "formatGroupLabel": [Function],
                           "getOptionLabel": [Function],
                           "getOptionValue": [Function],
+                          "hideDropdownIcon": false,
                           "hideSelectedOptions": false,
-                          "icon": undefined,
+                          "inputIcon": undefined,
                           "inputValue": "",
                           "isDisabled": false,
                           "isLoading": false,
@@ -1008,16 +1151,20 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                                 "closeMenuOnScroll": false,
                                 "closeMenuOnSelect": false,
                                 "components": Object {
+                                  "DropdownIndicator": [Function],
                                   "Option": [Function],
+                                  "ValueContainer": [Function],
                                 },
                                 "controlShouldRenderValue": true,
+                                "dropdownIcon": undefined,
                                 "escapeClearsValue": false,
                                 "filterOption": [Function],
                                 "formatGroupLabel": [Function],
                                 "getOptionLabel": [Function],
                                 "getOptionValue": [Function],
+                                "hideDropdownIcon": false,
                                 "hideSelectedOptions": false,
-                                "icon": undefined,
+                                "inputIcon": undefined,
                                 "inputValue": "",
                                 "isDisabled": false,
                                 "isLoading": false,
@@ -1109,7 +1256,7 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                               />
                             </EmotionCssPropInternal>
                           </IndicatorSeparator>
-                          <DropdownIndicator
+                          <LUKDropdownIndicator
                             clearValue={[Function]}
                             cx={[Function]}
                             getStyles={[Function]}
@@ -1136,16 +1283,20 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                                 "closeMenuOnScroll": false,
                                 "closeMenuOnSelect": false,
                                 "components": Object {
+                                  "DropdownIndicator": [Function],
                                   "Option": [Function],
+                                  "ValueContainer": [Function],
                                 },
                                 "controlShouldRenderValue": true,
+                                "dropdownIcon": undefined,
                                 "escapeClearsValue": false,
                                 "filterOption": [Function],
                                 "formatGroupLabel": [Function],
                                 "getOptionLabel": [Function],
                                 "getOptionValue": [Function],
+                                "hideDropdownIcon": false,
                                 "hideSelectedOptions": false,
-                                "icon": undefined,
+                                "inputIcon": undefined,
                                 "inputValue": "",
                                 "isDisabled": false,
                                 "isLoading": false,
@@ -1222,66 +1373,184 @@ exports[`CheckboxSelect snapshot render matches snapshot 1`] = `
                               }
                             }
                           >
-                            <EmotionCssPropInternal
-                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
-                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                              aria-hidden="true"
-                              className=""
-                              css={
+                            <DropdownIndicator
+                              clearValue={[Function]}
+                              cx={[Function]}
+                              getStyles={[Function]}
+                              getValue={[Function]}
+                              hasValue={false}
+                              innerProps={
                                 Object {
-                                  "color": "#b6bbc7",
-                                  "display": "flex",
-                                  "margin": "5px",
-                                  "padding": "0",
+                                  "aria-hidden": "true",
+                                  "onMouseDown": [Function],
+                                  "onTouchEnd": [Function],
                                 }
                               }
-                              onMouseDown={[Function]}
-                              onTouchEnd={[Function]}
+                              isDisabled={false}
+                              isFocused={false}
+                              isMulti={true}
+                              isRtl={false}
+                              options={Array []}
+                              selectOption={[Function]}
+                              selectProps={
+                                Object {
+                                  "backspaceRemovesValue": true,
+                                  "blurInputOnSelect": true,
+                                  "captureMenuScroll": false,
+                                  "closeMenuOnScroll": false,
+                                  "closeMenuOnSelect": false,
+                                  "components": Object {
+                                    "DropdownIndicator": [Function],
+                                    "Option": [Function],
+                                    "ValueContainer": [Function],
+                                  },
+                                  "controlShouldRenderValue": true,
+                                  "dropdownIcon": undefined,
+                                  "escapeClearsValue": false,
+                                  "filterOption": [Function],
+                                  "formatGroupLabel": [Function],
+                                  "getOptionLabel": [Function],
+                                  "getOptionValue": [Function],
+                                  "hideDropdownIcon": false,
+                                  "hideSelectedOptions": false,
+                                  "inputIcon": undefined,
+                                  "inputValue": "",
+                                  "isDisabled": false,
+                                  "isLoading": false,
+                                  "isMulti": true,
+                                  "isOptionDisabled": [Function],
+                                  "isRtl": false,
+                                  "isSearchable": true,
+                                  "loadingMessage": [Function],
+                                  "maxMenuHeight": 300,
+                                  "menuIsOpen": false,
+                                  "menuPlacement": "auto",
+                                  "menuPosition": "absolute",
+                                  "menuShouldBlockScroll": false,
+                                  "menuShouldScrollIntoView": true,
+                                  "minMenuHeight": 140,
+                                  "noOptionsMessage": [Function],
+                                  "onChange": [Function],
+                                  "onInputChange": [Function],
+                                  "onMenuClose": [Function],
+                                  "onMenuOpen": [Function],
+                                  "openMenuOnClick": true,
+                                  "openMenuOnFocus": false,
+                                  "options": Array [],
+                                  "pageSize": 5,
+                                  "placeholder": "Select...",
+                                  "screenReaderStatus": [Function],
+                                  "styles": Object {
+                                    "clearIndicator": [Function],
+                                    "container": [Function],
+                                    "control": [Function],
+                                    "dropdownIndicator": [Function],
+                                    "indicatorSeparator": [Function],
+                                    "indicatorsContainer": [Function],
+                                    "menu": [Function],
+                                    "menuList": [Function],
+                                    "menuPortal": [Function],
+                                    "option": [Function],
+                                    "singleValue": [Function],
+                                    "valueContainer": [Function],
+                                  },
+                                  "tabIndex": "0",
+                                  "tabSelectsValue": true,
+                                  "value": null,
+                                }
+                              }
+                              setValue={[Function]}
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(0, 0%, 100%)",
+                                    "neutral10": "hsl(0, 0%, 90%)",
+                                    "neutral20": "hsl(0, 0%, 80%)",
+                                    "neutral30": "hsl(0, 0%, 70%)",
+                                    "neutral40": "hsl(0, 0%, 60%)",
+                                    "neutral5": "hsl(0, 0%, 95%)",
+                                    "neutral50": "hsl(0, 0%, 50%)",
+                                    "neutral60": "hsl(0, 0%, 40%)",
+                                    "neutral70": "hsl(0, 0%, 30%)",
+                                    "neutral80": "hsl(0, 0%, 20%)",
+                                    "neutral90": "hsl(0, 0%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
+                                }
+                              }
                             >
-                              <div
+                              <EmotionCssPropInternal
+                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
                                 aria-hidden="true"
-                                className=" css-1vd5qh6-DropdownIndicator"
+                                className=""
+                                css={
+                                  Object {
+                                    "color": "#b6bbc7",
+                                    "display": "flex",
+                                    "margin": "5px",
+                                    "padding": "0",
+                                  }
+                                }
                                 onMouseDown={[Function]}
                                 onTouchEnd={[Function]}
                               >
-                                <DownChevron>
-                                  <Svg
-                                    size={20}
-                                  >
-                                    <EmotionCssPropInternal
-                                      __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
-                                      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
-                                      aria-hidden="true"
-                                      css={
-                                        Object {
-                                          "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
-                                          "name": "19bqh2r",
-                                          "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
-                                        }
-                                      }
-                                      focusable="false"
-                                      height={20}
-                                      viewBox="0 0 20 20"
-                                      width={20}
+                                <div
+                                  aria-hidden="true"
+                                  className=" css-1vd5qh6-DropdownIndicator"
+                                  onMouseDown={[Function]}
+                                  onTouchEnd={[Function]}
+                                >
+                                  <DownChevron>
+                                    <Svg
+                                      size={20}
                                     >
-                                      <svg
+                                      <EmotionCssPropInternal
+                                        __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
+                                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
                                         aria-hidden="true"
-                                        className="css-6q0nyr-Svg"
+                                        css={
+                                          Object {
+                                            "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
+                                            "name": "19bqh2r",
+                                            "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
+                                          }
+                                        }
                                         focusable="false"
                                         height={20}
                                         viewBox="0 0 20 20"
                                         width={20}
                                       >
-                                        <path
-                                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                                        />
-                                      </svg>
-                                    </EmotionCssPropInternal>
-                                  </Svg>
-                                </DownChevron>
-                              </div>
-                            </EmotionCssPropInternal>
-                          </DropdownIndicator>
+                                        <svg
+                                          aria-hidden="true"
+                                          className="css-6q0nyr-Svg"
+                                          focusable="false"
+                                          height={20}
+                                          viewBox="0 0 20 20"
+                                          width={20}
+                                        >
+                                          <path
+                                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                          />
+                                        </svg>
+                                      </EmotionCssPropInternal>
+                                    </Svg>
+                                  </DownChevron>
+                                </div>
+                              </EmotionCssPropInternal>
+                            </DropdownIndicator>
+                          </LUKDropdownIndicator>
                         </div>
                       </EmotionCssPropInternal>
                     </IndicatorsContainer>

--- a/src/select/src/components/__snapshots__/Creatable.test.js.snap
+++ b/src/select/src/components/__snapshots__/Creatable.test.js.snap
@@ -3,18 +3,22 @@
 exports[`Creatable render matches snapshot 1`] = `
 <Creatable>
   <SelectController
+    hideDropdownIcon={false}
     render={[Function]}
   >
     <StateManager
       components={
         Object {
+          "DropdownIndicator": [Function],
           "Option": [Function],
+          "ValueContainer": [Function],
         }
       }
       defaultInputValue=""
       defaultMenuIsOpen={false}
       defaultValue={null}
       filterOption={[Function]}
+      hideDropdownIcon={false}
       menuPlacement="auto"
       styles={
         Object {
@@ -37,13 +41,16 @@ exports[`Creatable render matches snapshot 1`] = `
         allowCreateWhileLoading={false}
         components={
           Object {
+            "DropdownIndicator": [Function],
             "Option": [Function],
+            "ValueContainer": [Function],
           }
         }
         createOptionPosition="last"
         filterOption={[Function]}
         formatCreateLabel={[Function]}
         getNewOptionData={[Function]}
+        hideDropdownIcon={false}
         inputValue=""
         isValidNewOption={[Function]}
         menuIsOpen={false}
@@ -79,7 +86,9 @@ exports[`Creatable render matches snapshot 1`] = `
           closeMenuOnSelect={true}
           components={
             Object {
+              "DropdownIndicator": [Function],
               "Option": [Function],
+              "ValueContainer": [Function],
             }
           }
           controlShouldRenderValue={true}
@@ -91,6 +100,7 @@ exports[`Creatable render matches snapshot 1`] = `
           getNewOptionData={[Function]}
           getOptionLabel={[Function]}
           getOptionValue={[Function]}
+          hideDropdownIcon={false}
           inputValue=""
           isDisabled={false}
           isLoading={false}
@@ -165,10 +175,13 @@ exports[`Creatable render matches snapshot 1`] = `
                 "closeMenuOnScroll": false,
                 "closeMenuOnSelect": true,
                 "components": Object {
+                  "DropdownIndicator": [Function],
                   "Option": [Function],
+                  "ValueContainer": [Function],
                 },
                 "controlShouldRenderValue": true,
                 "createOptionPosition": "last",
+                "dropdownIcon": undefined,
                 "escapeClearsValue": false,
                 "filterOption": [Function],
                 "formatCreateLabel": [Function],
@@ -176,7 +189,8 @@ exports[`Creatable render matches snapshot 1`] = `
                 "getNewOptionData": [Function],
                 "getOptionLabel": [Function],
                 "getOptionValue": [Function],
-                "icon": undefined,
+                "hideDropdownIcon": false,
+                "inputIcon": undefined,
                 "inputValue": "",
                 "isDisabled": false,
                 "isLoading": false,
@@ -304,10 +318,13 @@ exports[`Creatable render matches snapshot 1`] = `
                       "closeMenuOnScroll": false,
                       "closeMenuOnSelect": true,
                       "components": Object {
+                        "DropdownIndicator": [Function],
                         "Option": [Function],
+                        "ValueContainer": [Function],
                       },
                       "controlShouldRenderValue": true,
                       "createOptionPosition": "last",
+                      "dropdownIcon": undefined,
                       "escapeClearsValue": false,
                       "filterOption": [Function],
                       "formatCreateLabel": [Function],
@@ -315,7 +332,8 @@ exports[`Creatable render matches snapshot 1`] = `
                       "getNewOptionData": [Function],
                       "getOptionLabel": [Function],
                       "getOptionValue": [Function],
-                      "icon": undefined,
+                      "hideDropdownIcon": false,
+                      "inputIcon": undefined,
                       "inputValue": "",
                       "isDisabled": false,
                       "isLoading": false,
@@ -443,6 +461,7 @@ exports[`Creatable render matches snapshot 1`] = `
                         getStyles={[Function]}
                         getValue={[Function]}
                         hasValue={false}
+                        inputIcon={null}
                         isDisabled={false}
                         isMulti={false}
                         isRtl={false}
@@ -457,10 +476,13 @@ exports[`Creatable render matches snapshot 1`] = `
                             "closeMenuOnScroll": false,
                             "closeMenuOnSelect": true,
                             "components": Object {
+                              "DropdownIndicator": [Function],
                               "Option": [Function],
+                              "ValueContainer": [Function],
                             },
                             "controlShouldRenderValue": true,
                             "createOptionPosition": "last",
+                            "dropdownIcon": undefined,
                             "escapeClearsValue": false,
                             "filterOption": [Function],
                             "formatCreateLabel": [Function],
@@ -468,7 +490,8 @@ exports[`Creatable render matches snapshot 1`] = `
                             "getNewOptionData": [Function],
                             "getOptionLabel": [Function],
                             "getOptionValue": [Function],
-                            "icon": undefined,
+                            "hideDropdownIcon": false,
+                            "inputIcon": undefined,
                             "inputValue": "",
                             "isDisabled": false,
                             "isLoading": false,
@@ -546,381 +569,504 @@ exports[`Creatable render matches snapshot 1`] = `
                           }
                         }
                       >
-                        <EmotionCssPropInternal
-                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                          className=""
-                          css={
+                        <ValueContainer
+                          clearValue={[Function]}
+                          cx={[Function]}
+                          getStyles={[Function]}
+                          getValue={[Function]}
+                          hasValue={false}
+                          inputIcon={null}
+                          isDisabled={false}
+                          isMulti={false}
+                          isRtl={false}
+                          options={Array []}
+                          selectOption={[Function]}
+                          selectProps={
                             Object {
-                              "WebkitOverflowScrolling": "touch",
-                              "alignItems": "center",
-                              "boxSizing": "border-box",
-                              "display": "flex",
-                              "flex": 1,
-                              "flexWrap": "wrap",
-                              "overflow": "hidden",
-                              "padding": "0 10px",
-                              "position": "relative",
+                              "allowCreateWhileLoading": false,
+                              "backspaceRemovesValue": true,
+                              "blurInputOnSelect": true,
+                              "captureMenuScroll": false,
+                              "closeMenuOnScroll": false,
+                              "closeMenuOnSelect": true,
+                              "components": Object {
+                                "DropdownIndicator": [Function],
+                                "Option": [Function],
+                                "ValueContainer": [Function],
+                              },
+                              "controlShouldRenderValue": true,
+                              "createOptionPosition": "last",
+                              "dropdownIcon": undefined,
+                              "escapeClearsValue": false,
+                              "filterOption": [Function],
+                              "formatCreateLabel": [Function],
+                              "formatGroupLabel": [Function],
+                              "getNewOptionData": [Function],
+                              "getOptionLabel": [Function],
+                              "getOptionValue": [Function],
+                              "hideDropdownIcon": false,
+                              "inputIcon": undefined,
+                              "inputValue": "",
+                              "isDisabled": false,
+                              "isLoading": false,
+                              "isMulti": false,
+                              "isOptionDisabled": [Function],
+                              "isRtl": false,
+                              "isSearchable": true,
+                              "isValidNewOption": [Function],
+                              "loadingMessage": [Function],
+                              "maxMenuHeight": 300,
+                              "menuIsOpen": false,
+                              "menuPlacement": "auto",
+                              "menuPosition": "absolute",
+                              "menuShouldBlockScroll": false,
+                              "menuShouldScrollIntoView": true,
+                              "minMenuHeight": 140,
+                              "noOptionsMessage": [Function],
+                              "onChange": [Function],
+                              "onInputChange": [Function],
+                              "onMenuClose": [Function],
+                              "onMenuOpen": [Function],
+                              "openMenuOnClick": true,
+                              "openMenuOnFocus": false,
+                              "options": Array [],
+                              "pageSize": 5,
+                              "placeholder": "Select...",
+                              "screenReaderStatus": [Function],
+                              "styles": Object {
+                                "clearIndicator": [Function],
+                                "container": [Function],
+                                "control": [Function],
+                                "dropdownIndicator": [Function],
+                                "indicatorSeparator": [Function],
+                                "indicatorsContainer": [Function],
+                                "menu": [Function],
+                                "menuList": [Function],
+                                "menuPortal": [Function],
+                                "option": [Function],
+                                "singleValue": [Function],
+                                "valueContainer": [Function],
+                              },
+                              "tabIndex": "0",
+                              "tabSelectsValue": true,
+                              "value": null,
+                            }
+                          }
+                          setValue={[Function]}
+                          theme={
+                            Object {
+                              "borderRadius": 4,
+                              "colors": Object {
+                                "danger": "#DE350B",
+                                "dangerLight": "#FFBDAD",
+                                "neutral0": "hsl(0, 0%, 100%)",
+                                "neutral10": "hsl(0, 0%, 90%)",
+                                "neutral20": "hsl(0, 0%, 80%)",
+                                "neutral30": "hsl(0, 0%, 70%)",
+                                "neutral40": "hsl(0, 0%, 60%)",
+                                "neutral5": "hsl(0, 0%, 95%)",
+                                "neutral50": "hsl(0, 0%, 50%)",
+                                "neutral60": "hsl(0, 0%, 40%)",
+                                "neutral70": "hsl(0, 0%, 30%)",
+                                "neutral80": "hsl(0, 0%, 20%)",
+                                "neutral90": "hsl(0, 0%, 10%)",
+                                "primary": "#2684FF",
+                                "primary25": "#DEEBFF",
+                                "primary50": "#B2D4FF",
+                                "primary75": "#4C9AFF",
+                              },
+                              "spacing": Object {
+                                "baseUnit": 4,
+                                "controlHeight": 38,
+                                "menuGutter": 8,
+                              },
                             }
                           }
                         >
-                          <div
-                            className=" css-1gbz4ua"
+                          <EmotionCssPropInternal
+                            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                            className=""
+                            css={
+                              Object {
+                                "WebkitOverflowScrolling": "touch",
+                                "alignItems": "center",
+                                "boxSizing": "border-box",
+                                "display": "flex",
+                                "flex": 1,
+                                "flexWrap": "wrap",
+                                "overflow": "hidden",
+                                "padding": "0 10px",
+                                "position": "relative",
+                              }
+                            }
                           >
-                            <Placeholder
-                              clearValue={[Function]}
-                              cx={[Function]}
-                              getStyles={[Function]}
-                              getValue={[Function]}
-                              hasValue={false}
-                              isDisabled={false}
-                              isFocused={false}
-                              isMulti={false}
-                              isRtl={false}
-                              key="placeholder"
-                              options={Array []}
-                              selectOption={[Function]}
-                              selectProps={
-                                Object {
-                                  "allowCreateWhileLoading": false,
-                                  "backspaceRemovesValue": true,
-                                  "blurInputOnSelect": true,
-                                  "captureMenuScroll": false,
-                                  "closeMenuOnScroll": false,
-                                  "closeMenuOnSelect": true,
-                                  "components": Object {
-                                    "Option": [Function],
-                                  },
-                                  "controlShouldRenderValue": true,
-                                  "createOptionPosition": "last",
-                                  "escapeClearsValue": false,
-                                  "filterOption": [Function],
-                                  "formatCreateLabel": [Function],
-                                  "formatGroupLabel": [Function],
-                                  "getNewOptionData": [Function],
-                                  "getOptionLabel": [Function],
-                                  "getOptionValue": [Function],
-                                  "icon": undefined,
-                                  "inputValue": "",
-                                  "isDisabled": false,
-                                  "isLoading": false,
-                                  "isMulti": false,
-                                  "isOptionDisabled": [Function],
-                                  "isRtl": false,
-                                  "isSearchable": true,
-                                  "isValidNewOption": [Function],
-                                  "loadingMessage": [Function],
-                                  "maxMenuHeight": 300,
-                                  "menuIsOpen": false,
-                                  "menuPlacement": "auto",
-                                  "menuPosition": "absolute",
-                                  "menuShouldBlockScroll": false,
-                                  "menuShouldScrollIntoView": true,
-                                  "minMenuHeight": 140,
-                                  "noOptionsMessage": [Function],
-                                  "onChange": [Function],
-                                  "onInputChange": [Function],
-                                  "onMenuClose": [Function],
-                                  "onMenuOpen": [Function],
-                                  "openMenuOnClick": true,
-                                  "openMenuOnFocus": false,
-                                  "options": Array [],
-                                  "pageSize": 5,
-                                  "placeholder": "Select...",
-                                  "screenReaderStatus": [Function],
-                                  "styles": Object {
-                                    "clearIndicator": [Function],
-                                    "container": [Function],
-                                    "control": [Function],
-                                    "dropdownIndicator": [Function],
-                                    "indicatorSeparator": [Function],
-                                    "indicatorsContainer": [Function],
-                                    "menu": [Function],
-                                    "menuList": [Function],
-                                    "menuPortal": [Function],
-                                    "option": [Function],
-                                    "singleValue": [Function],
-                                    "valueContainer": [Function],
-                                  },
-                                  "tabIndex": "0",
-                                  "tabSelectsValue": true,
-                                  "value": null,
-                                }
-                              }
-                              setValue={[Function]}
-                              theme={
-                                Object {
-                                  "borderRadius": 4,
-                                  "colors": Object {
-                                    "danger": "#DE350B",
-                                    "dangerLight": "#FFBDAD",
-                                    "neutral0": "hsl(0, 0%, 100%)",
-                                    "neutral10": "hsl(0, 0%, 90%)",
-                                    "neutral20": "hsl(0, 0%, 80%)",
-                                    "neutral30": "hsl(0, 0%, 70%)",
-                                    "neutral40": "hsl(0, 0%, 60%)",
-                                    "neutral5": "hsl(0, 0%, 95%)",
-                                    "neutral50": "hsl(0, 0%, 50%)",
-                                    "neutral60": "hsl(0, 0%, 40%)",
-                                    "neutral70": "hsl(0, 0%, 30%)",
-                                    "neutral80": "hsl(0, 0%, 20%)",
-                                    "neutral90": "hsl(0, 0%, 10%)",
-                                    "primary": "#2684FF",
-                                    "primary25": "#DEEBFF",
-                                    "primary50": "#B2D4FF",
-                                    "primary75": "#4C9AFF",
-                                  },
-                                  "spacing": Object {
-                                    "baseUnit": 4,
-                                    "controlHeight": 38,
-                                    "menuGutter": 8,
-                                  },
-                                }
-                              }
+                            <div
+                              className=" css-1gbz4ua"
                             >
-                              <EmotionCssPropInternal
-                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Placeholder"
-                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                className=""
-                                css={
+                              <Placeholder
+                                clearValue={[Function]}
+                                cx={[Function]}
+                                getStyles={[Function]}
+                                getValue={[Function]}
+                                hasValue={false}
+                                isDisabled={false}
+                                isFocused={false}
+                                isMulti={false}
+                                isRtl={false}
+                                key="placeholder"
+                                options={Array []}
+                                selectOption={[Function]}
+                                selectProps={
                                   Object {
-                                    "boxSizing": "border-box",
-                                    "color": "hsl(0, 0%, 50%)",
-                                    "label": "placeholder",
-                                    "marginLeft": 2,
-                                    "marginRight": 2,
-                                    "position": "absolute",
-                                    "top": "50%",
-                                    "transform": "translateY(-50%)",
+                                    "allowCreateWhileLoading": false,
+                                    "backspaceRemovesValue": true,
+                                    "blurInputOnSelect": true,
+                                    "captureMenuScroll": false,
+                                    "closeMenuOnScroll": false,
+                                    "closeMenuOnSelect": true,
+                                    "components": Object {
+                                      "DropdownIndicator": [Function],
+                                      "Option": [Function],
+                                      "ValueContainer": [Function],
+                                    },
+                                    "controlShouldRenderValue": true,
+                                    "createOptionPosition": "last",
+                                    "dropdownIcon": undefined,
+                                    "escapeClearsValue": false,
+                                    "filterOption": [Function],
+                                    "formatCreateLabel": [Function],
+                                    "formatGroupLabel": [Function],
+                                    "getNewOptionData": [Function],
+                                    "getOptionLabel": [Function],
+                                    "getOptionValue": [Function],
+                                    "hideDropdownIcon": false,
+                                    "inputIcon": undefined,
+                                    "inputValue": "",
+                                    "isDisabled": false,
+                                    "isLoading": false,
+                                    "isMulti": false,
+                                    "isOptionDisabled": [Function],
+                                    "isRtl": false,
+                                    "isSearchable": true,
+                                    "isValidNewOption": [Function],
+                                    "loadingMessage": [Function],
+                                    "maxMenuHeight": 300,
+                                    "menuIsOpen": false,
+                                    "menuPlacement": "auto",
+                                    "menuPosition": "absolute",
+                                    "menuShouldBlockScroll": false,
+                                    "menuShouldScrollIntoView": true,
+                                    "minMenuHeight": 140,
+                                    "noOptionsMessage": [Function],
+                                    "onChange": [Function],
+                                    "onInputChange": [Function],
+                                    "onMenuClose": [Function],
+                                    "onMenuOpen": [Function],
+                                    "openMenuOnClick": true,
+                                    "openMenuOnFocus": false,
+                                    "options": Array [],
+                                    "pageSize": 5,
+                                    "placeholder": "Select...",
+                                    "screenReaderStatus": [Function],
+                                    "styles": Object {
+                                      "clearIndicator": [Function],
+                                      "container": [Function],
+                                      "control": [Function],
+                                      "dropdownIndicator": [Function],
+                                      "indicatorSeparator": [Function],
+                                      "indicatorsContainer": [Function],
+                                      "menu": [Function],
+                                      "menuList": [Function],
+                                      "menuPortal": [Function],
+                                      "option": [Function],
+                                      "singleValue": [Function],
+                                      "valueContainer": [Function],
+                                    },
+                                    "tabIndex": "0",
+                                    "tabSelectsValue": true,
+                                    "value": null,
+                                  }
+                                }
+                                setValue={[Function]}
+                                theme={
+                                  Object {
+                                    "borderRadius": 4,
+                                    "colors": Object {
+                                      "danger": "#DE350B",
+                                      "dangerLight": "#FFBDAD",
+                                      "neutral0": "hsl(0, 0%, 100%)",
+                                      "neutral10": "hsl(0, 0%, 90%)",
+                                      "neutral20": "hsl(0, 0%, 80%)",
+                                      "neutral30": "hsl(0, 0%, 70%)",
+                                      "neutral40": "hsl(0, 0%, 60%)",
+                                      "neutral5": "hsl(0, 0%, 95%)",
+                                      "neutral50": "hsl(0, 0%, 50%)",
+                                      "neutral60": "hsl(0, 0%, 40%)",
+                                      "neutral70": "hsl(0, 0%, 30%)",
+                                      "neutral80": "hsl(0, 0%, 20%)",
+                                      "neutral90": "hsl(0, 0%, 10%)",
+                                      "primary": "#2684FF",
+                                      "primary25": "#DEEBFF",
+                                      "primary50": "#B2D4FF",
+                                      "primary75": "#4C9AFF",
+                                    },
+                                    "spacing": Object {
+                                      "baseUnit": 4,
+                                      "controlHeight": 38,
+                                      "menuGutter": 8,
+                                    },
                                   }
                                 }
                               >
-                                <div
-                                  className=" css-1wa3eu0-placeholder"
-                                >
-                                  Select...
-                                </div>
-                              </EmotionCssPropInternal>
-                            </Placeholder>
-                            <Input
-                              aria-autocomplete="list"
-                              autoCapitalize="none"
-                              autoComplete="off"
-                              autoCorrect="off"
-                              cx={[Function]}
-                              getStyles={[Function]}
-                              id="react-select-2-input"
-                              innerRef={[Function]}
-                              isDisabled={false}
-                              isHidden={false}
-                              onBlur={[Function]}
-                              onChange={[Function]}
-                              onFocus={[Function]}
-                              selectProps={
-                                Object {
-                                  "allowCreateWhileLoading": false,
-                                  "backspaceRemovesValue": true,
-                                  "blurInputOnSelect": true,
-                                  "captureMenuScroll": false,
-                                  "closeMenuOnScroll": false,
-                                  "closeMenuOnSelect": true,
-                                  "components": Object {
-                                    "Option": [Function],
-                                  },
-                                  "controlShouldRenderValue": true,
-                                  "createOptionPosition": "last",
-                                  "escapeClearsValue": false,
-                                  "filterOption": [Function],
-                                  "formatCreateLabel": [Function],
-                                  "formatGroupLabel": [Function],
-                                  "getNewOptionData": [Function],
-                                  "getOptionLabel": [Function],
-                                  "getOptionValue": [Function],
-                                  "icon": undefined,
-                                  "inputValue": "",
-                                  "isDisabled": false,
-                                  "isLoading": false,
-                                  "isMulti": false,
-                                  "isOptionDisabled": [Function],
-                                  "isRtl": false,
-                                  "isSearchable": true,
-                                  "isValidNewOption": [Function],
-                                  "loadingMessage": [Function],
-                                  "maxMenuHeight": 300,
-                                  "menuIsOpen": false,
-                                  "menuPlacement": "auto",
-                                  "menuPosition": "absolute",
-                                  "menuShouldBlockScroll": false,
-                                  "menuShouldScrollIntoView": true,
-                                  "minMenuHeight": 140,
-                                  "noOptionsMessage": [Function],
-                                  "onChange": [Function],
-                                  "onInputChange": [Function],
-                                  "onMenuClose": [Function],
-                                  "onMenuOpen": [Function],
-                                  "openMenuOnClick": true,
-                                  "openMenuOnFocus": false,
-                                  "options": Array [],
-                                  "pageSize": 5,
-                                  "placeholder": "Select...",
-                                  "screenReaderStatus": [Function],
-                                  "styles": Object {
-                                    "clearIndicator": [Function],
-                                    "container": [Function],
-                                    "control": [Function],
-                                    "dropdownIndicator": [Function],
-                                    "indicatorSeparator": [Function],
-                                    "indicatorsContainer": [Function],
-                                    "menu": [Function],
-                                    "menuList": [Function],
-                                    "menuPortal": [Function],
-                                    "option": [Function],
-                                    "singleValue": [Function],
-                                    "valueContainer": [Function],
-                                  },
-                                  "tabIndex": "0",
-                                  "tabSelectsValue": true,
-                                  "value": null,
-                                }
-                              }
-                              spellCheck="false"
-                              tabIndex="0"
-                              theme={
-                                Object {
-                                  "borderRadius": 4,
-                                  "colors": Object {
-                                    "danger": "#DE350B",
-                                    "dangerLight": "#FFBDAD",
-                                    "neutral0": "hsl(0, 0%, 100%)",
-                                    "neutral10": "hsl(0, 0%, 90%)",
-                                    "neutral20": "hsl(0, 0%, 80%)",
-                                    "neutral30": "hsl(0, 0%, 70%)",
-                                    "neutral40": "hsl(0, 0%, 60%)",
-                                    "neutral5": "hsl(0, 0%, 95%)",
-                                    "neutral50": "hsl(0, 0%, 50%)",
-                                    "neutral60": "hsl(0, 0%, 40%)",
-                                    "neutral70": "hsl(0, 0%, 30%)",
-                                    "neutral80": "hsl(0, 0%, 20%)",
-                                    "neutral90": "hsl(0, 0%, 10%)",
-                                    "primary": "#2684FF",
-                                    "primary25": "#DEEBFF",
-                                    "primary50": "#B2D4FF",
-                                    "primary75": "#4C9AFF",
-                                  },
-                                  "spacing": Object {
-                                    "baseUnit": 4,
-                                    "controlHeight": 38,
-                                    "menuGutter": 8,
-                                  },
-                                }
-                              }
-                              type="text"
-                              value=""
-                            >
-                              <EmotionCssPropInternal
-                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
-                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                css={
-                                  Object {
-                                    "boxSizing": "border-box",
-                                    "color": "hsl(0, 0%, 20%)",
-                                    "margin": 2,
-                                    "paddingBottom": 2,
-                                    "paddingTop": 2,
-                                    "visibility": "visible",
-                                  }
-                                }
-                              >
-                                <div
-                                  className="css-b8ldur-Input"
-                                >
-                                  <AutosizeInput
-                                    aria-autocomplete="list"
-                                    autoCapitalize="none"
-                                    autoComplete="off"
-                                    autoCorrect="off"
-                                    className=""
-                                    disabled={false}
-                                    id="react-select-2-input"
-                                    injectStyles={true}
-                                    inputRef={[Function]}
-                                    inputStyle={
-                                      Object {
-                                        "background": 0,
-                                        "border": 0,
-                                        "color": "inherit",
-                                        "fontSize": "inherit",
-                                        "label": "input",
-                                        "opacity": 1,
-                                        "outline": 0,
-                                        "padding": 0,
-                                      }
+                                <EmotionCssPropInternal
+                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Placeholder"
+                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                  className=""
+                                  css={
+                                    Object {
+                                      "boxSizing": "border-box",
+                                      "color": "hsl(0, 0%, 50%)",
+                                      "label": "placeholder",
+                                      "marginLeft": 2,
+                                      "marginRight": 2,
+                                      "position": "absolute",
+                                      "top": "50%",
+                                      "transform": "translateY(-50%)",
                                     }
-                                    minWidth={1}
-                                    onBlur={[Function]}
-                                    onChange={[Function]}
-                                    onFocus={[Function]}
-                                    spellCheck="false"
-                                    tabIndex="0"
-                                    type="text"
-                                    value=""
+                                  }
+                                >
+                                  <div
+                                    className=" css-1wa3eu0-placeholder"
                                   >
-                                    <div
+                                    Select...
+                                  </div>
+                                </EmotionCssPropInternal>
+                              </Placeholder>
+                              <Input
+                                aria-autocomplete="list"
+                                autoCapitalize="none"
+                                autoComplete="off"
+                                autoCorrect="off"
+                                cx={[Function]}
+                                getStyles={[Function]}
+                                id="react-select-2-input"
+                                innerRef={[Function]}
+                                isDisabled={false}
+                                isHidden={false}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                selectProps={
+                                  Object {
+                                    "allowCreateWhileLoading": false,
+                                    "backspaceRemovesValue": true,
+                                    "blurInputOnSelect": true,
+                                    "captureMenuScroll": false,
+                                    "closeMenuOnScroll": false,
+                                    "closeMenuOnSelect": true,
+                                    "components": Object {
+                                      "DropdownIndicator": [Function],
+                                      "Option": [Function],
+                                      "ValueContainer": [Function],
+                                    },
+                                    "controlShouldRenderValue": true,
+                                    "createOptionPosition": "last",
+                                    "dropdownIcon": undefined,
+                                    "escapeClearsValue": false,
+                                    "filterOption": [Function],
+                                    "formatCreateLabel": [Function],
+                                    "formatGroupLabel": [Function],
+                                    "getNewOptionData": [Function],
+                                    "getOptionLabel": [Function],
+                                    "getOptionValue": [Function],
+                                    "hideDropdownIcon": false,
+                                    "inputIcon": undefined,
+                                    "inputValue": "",
+                                    "isDisabled": false,
+                                    "isLoading": false,
+                                    "isMulti": false,
+                                    "isOptionDisabled": [Function],
+                                    "isRtl": false,
+                                    "isSearchable": true,
+                                    "isValidNewOption": [Function],
+                                    "loadingMessage": [Function],
+                                    "maxMenuHeight": 300,
+                                    "menuIsOpen": false,
+                                    "menuPlacement": "auto",
+                                    "menuPosition": "absolute",
+                                    "menuShouldBlockScroll": false,
+                                    "menuShouldScrollIntoView": true,
+                                    "minMenuHeight": 140,
+                                    "noOptionsMessage": [Function],
+                                    "onChange": [Function],
+                                    "onInputChange": [Function],
+                                    "onMenuClose": [Function],
+                                    "onMenuOpen": [Function],
+                                    "openMenuOnClick": true,
+                                    "openMenuOnFocus": false,
+                                    "options": Array [],
+                                    "pageSize": 5,
+                                    "placeholder": "Select...",
+                                    "screenReaderStatus": [Function],
+                                    "styles": Object {
+                                      "clearIndicator": [Function],
+                                      "container": [Function],
+                                      "control": [Function],
+                                      "dropdownIndicator": [Function],
+                                      "indicatorSeparator": [Function],
+                                      "indicatorsContainer": [Function],
+                                      "menu": [Function],
+                                      "menuList": [Function],
+                                      "menuPortal": [Function],
+                                      "option": [Function],
+                                      "singleValue": [Function],
+                                      "valueContainer": [Function],
+                                    },
+                                    "tabIndex": "0",
+                                    "tabSelectsValue": true,
+                                    "value": null,
+                                  }
+                                }
+                                spellCheck="false"
+                                tabIndex="0"
+                                theme={
+                                  Object {
+                                    "borderRadius": 4,
+                                    "colors": Object {
+                                      "danger": "#DE350B",
+                                      "dangerLight": "#FFBDAD",
+                                      "neutral0": "hsl(0, 0%, 100%)",
+                                      "neutral10": "hsl(0, 0%, 90%)",
+                                      "neutral20": "hsl(0, 0%, 80%)",
+                                      "neutral30": "hsl(0, 0%, 70%)",
+                                      "neutral40": "hsl(0, 0%, 60%)",
+                                      "neutral5": "hsl(0, 0%, 95%)",
+                                      "neutral50": "hsl(0, 0%, 50%)",
+                                      "neutral60": "hsl(0, 0%, 40%)",
+                                      "neutral70": "hsl(0, 0%, 30%)",
+                                      "neutral80": "hsl(0, 0%, 20%)",
+                                      "neutral90": "hsl(0, 0%, 10%)",
+                                      "primary": "#2684FF",
+                                      "primary25": "#DEEBFF",
+                                      "primary50": "#B2D4FF",
+                                      "primary75": "#4C9AFF",
+                                    },
+                                    "spacing": Object {
+                                      "baseUnit": 4,
+                                      "controlHeight": 38,
+                                      "menuGutter": 8,
+                                    },
+                                  }
+                                }
+                                type="text"
+                                value=""
+                              >
+                                <EmotionCssPropInternal
+                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
+                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                  css={
+                                    Object {
+                                      "boxSizing": "border-box",
+                                      "color": "hsl(0, 0%, 20%)",
+                                      "margin": 2,
+                                      "paddingBottom": 2,
+                                      "paddingTop": 2,
+                                      "visibility": "visible",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="css-b8ldur-Input"
+                                  >
+                                    <AutosizeInput
+                                      aria-autocomplete="list"
+                                      autoCapitalize="none"
+                                      autoComplete="off"
+                                      autoCorrect="off"
                                       className=""
-                                      style={
+                                      disabled={false}
+                                      id="react-select-2-input"
+                                      injectStyles={true}
+                                      inputRef={[Function]}
+                                      inputStyle={
                                         Object {
-                                          "display": "inline-block",
+                                          "background": 0,
+                                          "border": 0,
+                                          "color": "inherit",
+                                          "fontSize": "inherit",
+                                          "label": "input",
+                                          "opacity": 1,
+                                          "outline": 0,
+                                          "padding": 0,
                                         }
                                       }
+                                      minWidth={1}
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      spellCheck="false"
+                                      tabIndex="0"
+                                      type="text"
+                                      value=""
                                     >
-                                      <input
-                                        aria-autocomplete="list"
-                                        autoCapitalize="none"
-                                        autoComplete="off"
-                                        autoCorrect="off"
-                                        disabled={false}
-                                        id="react-select-2-input"
-                                        onBlur={[Function]}
-                                        onChange={[Function]}
-                                        onFocus={[Function]}
-                                        spellCheck="false"
-                                        style={
-                                          Object {
-                                            "background": 0,
-                                            "border": 0,
-                                            "boxSizing": "content-box",
-                                            "color": "inherit",
-                                            "fontSize": "inherit",
-                                            "label": "input",
-                                            "opacity": 1,
-                                            "outline": 0,
-                                            "padding": 0,
-                                            "width": "2px",
-                                          }
-                                        }
-                                        tabIndex="0"
-                                        type="text"
-                                        value=""
-                                      />
                                       <div
+                                        className=""
                                         style={
                                           Object {
-                                            "height": 0,
-                                            "left": 0,
-                                            "overflow": "scroll",
-                                            "position": "absolute",
-                                            "top": 0,
-                                            "visibility": "hidden",
-                                            "whiteSpace": "pre",
+                                            "display": "inline-block",
                                           }
                                         }
-                                      />
-                                    </div>
-                                  </AutosizeInput>
-                                </div>
-                              </EmotionCssPropInternal>
-                            </Input>
-                          </div>
-                        </EmotionCssPropInternal>
+                                      >
+                                        <input
+                                          aria-autocomplete="list"
+                                          autoCapitalize="none"
+                                          autoComplete="off"
+                                          autoCorrect="off"
+                                          disabled={false}
+                                          id="react-select-2-input"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          onFocus={[Function]}
+                                          spellCheck="false"
+                                          style={
+                                            Object {
+                                              "background": 0,
+                                              "border": 0,
+                                              "boxSizing": "content-box",
+                                              "color": "inherit",
+                                              "fontSize": "inherit",
+                                              "label": "input",
+                                              "opacity": 1,
+                                              "outline": 0,
+                                              "padding": 0,
+                                              "width": "2px",
+                                            }
+                                          }
+                                          tabIndex="0"
+                                          type="text"
+                                          value=""
+                                        />
+                                        <div
+                                          style={
+                                            Object {
+                                              "height": 0,
+                                              "left": 0,
+                                              "overflow": "scroll",
+                                              "position": "absolute",
+                                              "top": 0,
+                                              "visibility": "hidden",
+                                              "whiteSpace": "pre",
+                                            }
+                                          }
+                                        />
+                                      </div>
+                                    </AutosizeInput>
+                                  </div>
+                                </EmotionCssPropInternal>
+                              </Input>
+                            </div>
+                          </EmotionCssPropInternal>
+                        </ValueContainer>
                       </ValueContainer>
                       <IndicatorsContainer
                         clearValue={[Function]}
@@ -942,10 +1088,13 @@ exports[`Creatable render matches snapshot 1`] = `
                             "closeMenuOnScroll": false,
                             "closeMenuOnSelect": true,
                             "components": Object {
+                              "DropdownIndicator": [Function],
                               "Option": [Function],
+                              "ValueContainer": [Function],
                             },
                             "controlShouldRenderValue": true,
                             "createOptionPosition": "last",
+                            "dropdownIcon": undefined,
                             "escapeClearsValue": false,
                             "filterOption": [Function],
                             "formatCreateLabel": [Function],
@@ -953,7 +1102,8 @@ exports[`Creatable render matches snapshot 1`] = `
                             "getNewOptionData": [Function],
                             "getOptionLabel": [Function],
                             "getOptionValue": [Function],
-                            "icon": undefined,
+                            "hideDropdownIcon": false,
+                            "inputIcon": undefined,
                             "inputValue": "",
                             "isDisabled": false,
                             "isLoading": false,
@@ -1071,10 +1221,13 @@ exports[`Creatable render matches snapshot 1`] = `
                                   "closeMenuOnScroll": false,
                                   "closeMenuOnSelect": true,
                                   "components": Object {
+                                    "DropdownIndicator": [Function],
                                     "Option": [Function],
+                                    "ValueContainer": [Function],
                                   },
                                   "controlShouldRenderValue": true,
                                   "createOptionPosition": "last",
+                                  "dropdownIcon": undefined,
                                   "escapeClearsValue": false,
                                   "filterOption": [Function],
                                   "formatCreateLabel": [Function],
@@ -1082,7 +1235,8 @@ exports[`Creatable render matches snapshot 1`] = `
                                   "getNewOptionData": [Function],
                                   "getOptionLabel": [Function],
                                   "getOptionValue": [Function],
-                                  "icon": undefined,
+                                  "hideDropdownIcon": false,
+                                  "inputIcon": undefined,
                                   "inputValue": "",
                                   "isDisabled": false,
                                   "isLoading": false,
@@ -1175,7 +1329,7 @@ exports[`Creatable render matches snapshot 1`] = `
                                 />
                               </EmotionCssPropInternal>
                             </IndicatorSeparator>
-                            <DropdownIndicator
+                            <LUKDropdownIndicator
                               clearValue={[Function]}
                               cx={[Function]}
                               getStyles={[Function]}
@@ -1203,10 +1357,13 @@ exports[`Creatable render matches snapshot 1`] = `
                                   "closeMenuOnScroll": false,
                                   "closeMenuOnSelect": true,
                                   "components": Object {
+                                    "DropdownIndicator": [Function],
                                     "Option": [Function],
+                                    "ValueContainer": [Function],
                                   },
                                   "controlShouldRenderValue": true,
                                   "createOptionPosition": "last",
+                                  "dropdownIcon": undefined,
                                   "escapeClearsValue": false,
                                   "filterOption": [Function],
                                   "formatCreateLabel": [Function],
@@ -1214,7 +1371,8 @@ exports[`Creatable render matches snapshot 1`] = `
                                   "getNewOptionData": [Function],
                                   "getOptionLabel": [Function],
                                   "getOptionValue": [Function],
-                                  "icon": undefined,
+                                  "hideDropdownIcon": false,
+                                  "inputIcon": undefined,
                                   "inputValue": "",
                                   "isDisabled": false,
                                   "isLoading": false,
@@ -1292,66 +1450,188 @@ exports[`Creatable render matches snapshot 1`] = `
                                 }
                               }
                             >
-                              <EmotionCssPropInternal
-                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
-                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                aria-hidden="true"
-                                className=""
-                                css={
+                              <DropdownIndicator
+                                clearValue={[Function]}
+                                cx={[Function]}
+                                getStyles={[Function]}
+                                getValue={[Function]}
+                                hasValue={false}
+                                innerProps={
                                   Object {
-                                    "color": "#b6bbc7",
-                                    "display": "flex",
-                                    "margin": "5px",
-                                    "padding": "0",
+                                    "aria-hidden": "true",
+                                    "onMouseDown": [Function],
+                                    "onTouchEnd": [Function],
                                   }
                                 }
-                                onMouseDown={[Function]}
-                                onTouchEnd={[Function]}
+                                isDisabled={false}
+                                isFocused={false}
+                                isMulti={false}
+                                isRtl={false}
+                                options={Array []}
+                                selectOption={[Function]}
+                                selectProps={
+                                  Object {
+                                    "allowCreateWhileLoading": false,
+                                    "backspaceRemovesValue": true,
+                                    "blurInputOnSelect": true,
+                                    "captureMenuScroll": false,
+                                    "closeMenuOnScroll": false,
+                                    "closeMenuOnSelect": true,
+                                    "components": Object {
+                                      "DropdownIndicator": [Function],
+                                      "Option": [Function],
+                                      "ValueContainer": [Function],
+                                    },
+                                    "controlShouldRenderValue": true,
+                                    "createOptionPosition": "last",
+                                    "dropdownIcon": undefined,
+                                    "escapeClearsValue": false,
+                                    "filterOption": [Function],
+                                    "formatCreateLabel": [Function],
+                                    "formatGroupLabel": [Function],
+                                    "getNewOptionData": [Function],
+                                    "getOptionLabel": [Function],
+                                    "getOptionValue": [Function],
+                                    "hideDropdownIcon": false,
+                                    "inputIcon": undefined,
+                                    "inputValue": "",
+                                    "isDisabled": false,
+                                    "isLoading": false,
+                                    "isMulti": false,
+                                    "isOptionDisabled": [Function],
+                                    "isRtl": false,
+                                    "isSearchable": true,
+                                    "isValidNewOption": [Function],
+                                    "loadingMessage": [Function],
+                                    "maxMenuHeight": 300,
+                                    "menuIsOpen": false,
+                                    "menuPlacement": "auto",
+                                    "menuPosition": "absolute",
+                                    "menuShouldBlockScroll": false,
+                                    "menuShouldScrollIntoView": true,
+                                    "minMenuHeight": 140,
+                                    "noOptionsMessage": [Function],
+                                    "onChange": [Function],
+                                    "onInputChange": [Function],
+                                    "onMenuClose": [Function],
+                                    "onMenuOpen": [Function],
+                                    "openMenuOnClick": true,
+                                    "openMenuOnFocus": false,
+                                    "options": Array [],
+                                    "pageSize": 5,
+                                    "placeholder": "Select...",
+                                    "screenReaderStatus": [Function],
+                                    "styles": Object {
+                                      "clearIndicator": [Function],
+                                      "container": [Function],
+                                      "control": [Function],
+                                      "dropdownIndicator": [Function],
+                                      "indicatorSeparator": [Function],
+                                      "indicatorsContainer": [Function],
+                                      "menu": [Function],
+                                      "menuList": [Function],
+                                      "menuPortal": [Function],
+                                      "option": [Function],
+                                      "singleValue": [Function],
+                                      "valueContainer": [Function],
+                                    },
+                                    "tabIndex": "0",
+                                    "tabSelectsValue": true,
+                                    "value": null,
+                                  }
+                                }
+                                setValue={[Function]}
+                                theme={
+                                  Object {
+                                    "borderRadius": 4,
+                                    "colors": Object {
+                                      "danger": "#DE350B",
+                                      "dangerLight": "#FFBDAD",
+                                      "neutral0": "hsl(0, 0%, 100%)",
+                                      "neutral10": "hsl(0, 0%, 90%)",
+                                      "neutral20": "hsl(0, 0%, 80%)",
+                                      "neutral30": "hsl(0, 0%, 70%)",
+                                      "neutral40": "hsl(0, 0%, 60%)",
+                                      "neutral5": "hsl(0, 0%, 95%)",
+                                      "neutral50": "hsl(0, 0%, 50%)",
+                                      "neutral60": "hsl(0, 0%, 40%)",
+                                      "neutral70": "hsl(0, 0%, 30%)",
+                                      "neutral80": "hsl(0, 0%, 20%)",
+                                      "neutral90": "hsl(0, 0%, 10%)",
+                                      "primary": "#2684FF",
+                                      "primary25": "#DEEBFF",
+                                      "primary50": "#B2D4FF",
+                                      "primary75": "#4C9AFF",
+                                    },
+                                    "spacing": Object {
+                                      "baseUnit": 4,
+                                      "controlHeight": 38,
+                                      "menuGutter": 8,
+                                    },
+                                  }
+                                }
                               >
-                                <div
+                                <EmotionCssPropInternal
+                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
+                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
                                   aria-hidden="true"
-                                  className=" css-1vd5qh6-DropdownIndicator"
+                                  className=""
+                                  css={
+                                    Object {
+                                      "color": "#b6bbc7",
+                                      "display": "flex",
+                                      "margin": "5px",
+                                      "padding": "0",
+                                    }
+                                  }
                                   onMouseDown={[Function]}
                                   onTouchEnd={[Function]}
                                 >
-                                  <DownChevron>
-                                    <Svg
-                                      size={20}
-                                    >
-                                      <EmotionCssPropInternal
-                                        __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
-                                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
-                                        aria-hidden="true"
-                                        css={
-                                          Object {
-                                            "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
-                                            "name": "19bqh2r",
-                                            "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
-                                          }
-                                        }
-                                        focusable="false"
-                                        height={20}
-                                        viewBox="0 0 20 20"
-                                        width={20}
+                                  <div
+                                    aria-hidden="true"
+                                    className=" css-1vd5qh6-DropdownIndicator"
+                                    onMouseDown={[Function]}
+                                    onTouchEnd={[Function]}
+                                  >
+                                    <DownChevron>
+                                      <Svg
+                                        size={20}
                                       >
-                                        <svg
+                                        <EmotionCssPropInternal
+                                          __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
+                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
                                           aria-hidden="true"
-                                          className="css-6q0nyr-Svg"
+                                          css={
+                                            Object {
+                                              "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
+                                              "name": "19bqh2r",
+                                              "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
+                                            }
+                                          }
                                           focusable="false"
                                           height={20}
                                           viewBox="0 0 20 20"
                                           width={20}
                                         >
-                                          <path
-                                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                                          />
-                                        </svg>
-                                      </EmotionCssPropInternal>
-                                    </Svg>
-                                  </DownChevron>
-                                </div>
-                              </EmotionCssPropInternal>
-                            </DropdownIndicator>
+                                          <svg
+                                            aria-hidden="true"
+                                            className="css-6q0nyr-Svg"
+                                            focusable="false"
+                                            height={20}
+                                            viewBox="0 0 20 20"
+                                            width={20}
+                                          >
+                                            <path
+                                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                            />
+                                          </svg>
+                                        </EmotionCssPropInternal>
+                                      </Svg>
+                                    </DownChevron>
+                                  </div>
+                                </EmotionCssPropInternal>
+                              </DropdownIndicator>
+                            </LUKDropdownIndicator>
                           </div>
                         </EmotionCssPropInternal>
                       </IndicatorsContainer>

--- a/src/select/src/components/__snapshots__/Select.test.js.snap
+++ b/src/select/src/components/__snapshots__/Select.test.js.snap
@@ -3,18 +3,22 @@
 exports[`Select snapshot render matches snapshot 1`] = `
 <Select>
   <SelectController
+    hideDropdownIcon={false}
     render={[Function]}
   >
     <StateManager
       components={
         Object {
+          "DropdownIndicator": [Function],
           "Option": [Function],
+          "ValueContainer": [Function],
         }
       }
       defaultInputValue=""
       defaultMenuIsOpen={false}
       defaultValue={null}
       filterOption={[Function]}
+      hideDropdownIcon={false}
       menuPlacement="auto"
       styles={
         Object {
@@ -41,7 +45,9 @@ exports[`Select snapshot render matches snapshot 1`] = `
         closeMenuOnSelect={true}
         components={
           Object {
+            "DropdownIndicator": [Function],
             "Option": [Function],
+            "ValueContainer": [Function],
           }
         }
         controlShouldRenderValue={true}
@@ -50,6 +56,7 @@ exports[`Select snapshot render matches snapshot 1`] = `
         formatGroupLabel={[Function]}
         getOptionLabel={[Function]}
         getOptionValue={[Function]}
+        hideDropdownIcon={false}
         inputValue=""
         isDisabled={false}
         isLoading={false}
@@ -122,15 +129,19 @@ exports[`Select snapshot render matches snapshot 1`] = `
               "closeMenuOnScroll": false,
               "closeMenuOnSelect": true,
               "components": Object {
+                "DropdownIndicator": [Function],
                 "Option": [Function],
+                "ValueContainer": [Function],
               },
               "controlShouldRenderValue": true,
+              "dropdownIcon": undefined,
               "escapeClearsValue": false,
               "filterOption": [Function],
               "formatGroupLabel": [Function],
               "getOptionLabel": [Function],
               "getOptionValue": [Function],
-              "icon": undefined,
+              "hideDropdownIcon": false,
+              "inputIcon": undefined,
               "inputValue": "",
               "isDisabled": false,
               "isLoading": false,
@@ -256,15 +267,19 @@ exports[`Select snapshot render matches snapshot 1`] = `
                     "closeMenuOnScroll": false,
                     "closeMenuOnSelect": true,
                     "components": Object {
+                      "DropdownIndicator": [Function],
                       "Option": [Function],
+                      "ValueContainer": [Function],
                     },
                     "controlShouldRenderValue": true,
+                    "dropdownIcon": undefined,
                     "escapeClearsValue": false,
                     "filterOption": [Function],
                     "formatGroupLabel": [Function],
                     "getOptionLabel": [Function],
                     "getOptionValue": [Function],
-                    "icon": undefined,
+                    "hideDropdownIcon": false,
+                    "inputIcon": undefined,
                     "inputValue": "",
                     "isDisabled": false,
                     "isLoading": false,
@@ -391,6 +406,7 @@ exports[`Select snapshot render matches snapshot 1`] = `
                       getStyles={[Function]}
                       getValue={[Function]}
                       hasValue={false}
+                      inputIcon={null}
                       isDisabled={false}
                       isMulti={false}
                       isRtl={false}
@@ -404,15 +420,19 @@ exports[`Select snapshot render matches snapshot 1`] = `
                           "closeMenuOnScroll": false,
                           "closeMenuOnSelect": true,
                           "components": Object {
+                            "DropdownIndicator": [Function],
                             "Option": [Function],
+                            "ValueContainer": [Function],
                           },
                           "controlShouldRenderValue": true,
+                          "dropdownIcon": undefined,
                           "escapeClearsValue": false,
                           "filterOption": [Function],
                           "formatGroupLabel": [Function],
                           "getOptionLabel": [Function],
                           "getOptionValue": [Function],
-                          "icon": undefined,
+                          "hideDropdownIcon": false,
+                          "inputIcon": undefined,
                           "inputValue": "",
                           "isDisabled": false,
                           "isLoading": false,
@@ -489,371 +509,489 @@ exports[`Select snapshot render matches snapshot 1`] = `
                         }
                       }
                     >
-                      <EmotionCssPropInternal
-                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                        className=""
-                        css={
+                      <ValueContainer
+                        clearValue={[Function]}
+                        cx={[Function]}
+                        getStyles={[Function]}
+                        getValue={[Function]}
+                        hasValue={false}
+                        inputIcon={null}
+                        isDisabled={false}
+                        isMulti={false}
+                        isRtl={false}
+                        options={Array []}
+                        selectOption={[Function]}
+                        selectProps={
                           Object {
-                            "WebkitOverflowScrolling": "touch",
-                            "alignItems": "center",
-                            "boxSizing": "border-box",
-                            "display": "flex",
-                            "flex": 1,
-                            "flexWrap": "wrap",
-                            "overflow": "hidden",
-                            "padding": "0 10px",
-                            "position": "relative",
+                            "backspaceRemovesValue": true,
+                            "blurInputOnSelect": true,
+                            "captureMenuScroll": false,
+                            "closeMenuOnScroll": false,
+                            "closeMenuOnSelect": true,
+                            "components": Object {
+                              "DropdownIndicator": [Function],
+                              "Option": [Function],
+                              "ValueContainer": [Function],
+                            },
+                            "controlShouldRenderValue": true,
+                            "dropdownIcon": undefined,
+                            "escapeClearsValue": false,
+                            "filterOption": [Function],
+                            "formatGroupLabel": [Function],
+                            "getOptionLabel": [Function],
+                            "getOptionValue": [Function],
+                            "hideDropdownIcon": false,
+                            "inputIcon": undefined,
+                            "inputValue": "",
+                            "isDisabled": false,
+                            "isLoading": false,
+                            "isMulti": false,
+                            "isOptionDisabled": [Function],
+                            "isRtl": false,
+                            "isSearchable": true,
+                            "loadingMessage": [Function],
+                            "maxMenuHeight": 300,
+                            "menuIsOpen": false,
+                            "menuPlacement": "auto",
+                            "menuPosition": "absolute",
+                            "menuShouldBlockScroll": false,
+                            "menuShouldScrollIntoView": true,
+                            "minMenuHeight": 140,
+                            "noOptionsMessage": [Function],
+                            "onChange": [Function],
+                            "onInputChange": [Function],
+                            "onMenuClose": [Function],
+                            "onMenuOpen": [Function],
+                            "openMenuOnClick": true,
+                            "openMenuOnFocus": false,
+                            "options": Array [],
+                            "pageSize": 5,
+                            "placeholder": "Select...",
+                            "screenReaderStatus": [Function],
+                            "styles": Object {
+                              "clearIndicator": [Function],
+                              "container": [Function],
+                              "control": [Function],
+                              "dropdownIndicator": [Function],
+                              "indicatorSeparator": [Function],
+                              "indicatorsContainer": [Function],
+                              "menu": [Function],
+                              "menuList": [Function],
+                              "menuPortal": [Function],
+                              "option": [Function],
+                              "singleValue": [Function],
+                              "valueContainer": [Function],
+                            },
+                            "tabIndex": "0",
+                            "tabSelectsValue": true,
+                            "value": null,
+                          }
+                        }
+                        setValue={[Function]}
+                        theme={
+                          Object {
+                            "borderRadius": 4,
+                            "colors": Object {
+                              "danger": "#DE350B",
+                              "dangerLight": "#FFBDAD",
+                              "neutral0": "hsl(0, 0%, 100%)",
+                              "neutral10": "hsl(0, 0%, 90%)",
+                              "neutral20": "hsl(0, 0%, 80%)",
+                              "neutral30": "hsl(0, 0%, 70%)",
+                              "neutral40": "hsl(0, 0%, 60%)",
+                              "neutral5": "hsl(0, 0%, 95%)",
+                              "neutral50": "hsl(0, 0%, 50%)",
+                              "neutral60": "hsl(0, 0%, 40%)",
+                              "neutral70": "hsl(0, 0%, 30%)",
+                              "neutral80": "hsl(0, 0%, 20%)",
+                              "neutral90": "hsl(0, 0%, 10%)",
+                              "primary": "#2684FF",
+                              "primary25": "#DEEBFF",
+                              "primary50": "#B2D4FF",
+                              "primary75": "#4C9AFF",
+                            },
+                            "spacing": Object {
+                              "baseUnit": 4,
+                              "controlHeight": 38,
+                              "menuGutter": 8,
+                            },
                           }
                         }
                       >
-                        <div
-                          className=" css-1gbz4ua"
+                        <EmotionCssPropInternal
+                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                          className=""
+                          css={
+                            Object {
+                              "WebkitOverflowScrolling": "touch",
+                              "alignItems": "center",
+                              "boxSizing": "border-box",
+                              "display": "flex",
+                              "flex": 1,
+                              "flexWrap": "wrap",
+                              "overflow": "hidden",
+                              "padding": "0 10px",
+                              "position": "relative",
+                            }
+                          }
                         >
-                          <Placeholder
-                            clearValue={[Function]}
-                            cx={[Function]}
-                            getStyles={[Function]}
-                            getValue={[Function]}
-                            hasValue={false}
-                            isDisabled={false}
-                            isFocused={false}
-                            isMulti={false}
-                            isRtl={false}
-                            key="placeholder"
-                            options={Array []}
-                            selectOption={[Function]}
-                            selectProps={
-                              Object {
-                                "backspaceRemovesValue": true,
-                                "blurInputOnSelect": true,
-                                "captureMenuScroll": false,
-                                "closeMenuOnScroll": false,
-                                "closeMenuOnSelect": true,
-                                "components": Object {
-                                  "Option": [Function],
-                                },
-                                "controlShouldRenderValue": true,
-                                "escapeClearsValue": false,
-                                "filterOption": [Function],
-                                "formatGroupLabel": [Function],
-                                "getOptionLabel": [Function],
-                                "getOptionValue": [Function],
-                                "icon": undefined,
-                                "inputValue": "",
-                                "isDisabled": false,
-                                "isLoading": false,
-                                "isMulti": false,
-                                "isOptionDisabled": [Function],
-                                "isRtl": false,
-                                "isSearchable": true,
-                                "loadingMessage": [Function],
-                                "maxMenuHeight": 300,
-                                "menuIsOpen": false,
-                                "menuPlacement": "auto",
-                                "menuPosition": "absolute",
-                                "menuShouldBlockScroll": false,
-                                "menuShouldScrollIntoView": true,
-                                "minMenuHeight": 140,
-                                "noOptionsMessage": [Function],
-                                "onChange": [Function],
-                                "onInputChange": [Function],
-                                "onMenuClose": [Function],
-                                "onMenuOpen": [Function],
-                                "openMenuOnClick": true,
-                                "openMenuOnFocus": false,
-                                "options": Array [],
-                                "pageSize": 5,
-                                "placeholder": "Select...",
-                                "screenReaderStatus": [Function],
-                                "styles": Object {
-                                  "clearIndicator": [Function],
-                                  "container": [Function],
-                                  "control": [Function],
-                                  "dropdownIndicator": [Function],
-                                  "indicatorSeparator": [Function],
-                                  "indicatorsContainer": [Function],
-                                  "menu": [Function],
-                                  "menuList": [Function],
-                                  "menuPortal": [Function],
-                                  "option": [Function],
-                                  "singleValue": [Function],
-                                  "valueContainer": [Function],
-                                },
-                                "tabIndex": "0",
-                                "tabSelectsValue": true,
-                                "value": null,
-                              }
-                            }
-                            setValue={[Function]}
-                            theme={
-                              Object {
-                                "borderRadius": 4,
-                                "colors": Object {
-                                  "danger": "#DE350B",
-                                  "dangerLight": "#FFBDAD",
-                                  "neutral0": "hsl(0, 0%, 100%)",
-                                  "neutral10": "hsl(0, 0%, 90%)",
-                                  "neutral20": "hsl(0, 0%, 80%)",
-                                  "neutral30": "hsl(0, 0%, 70%)",
-                                  "neutral40": "hsl(0, 0%, 60%)",
-                                  "neutral5": "hsl(0, 0%, 95%)",
-                                  "neutral50": "hsl(0, 0%, 50%)",
-                                  "neutral60": "hsl(0, 0%, 40%)",
-                                  "neutral70": "hsl(0, 0%, 30%)",
-                                  "neutral80": "hsl(0, 0%, 20%)",
-                                  "neutral90": "hsl(0, 0%, 10%)",
-                                  "primary": "#2684FF",
-                                  "primary25": "#DEEBFF",
-                                  "primary50": "#B2D4FF",
-                                  "primary75": "#4C9AFF",
-                                },
-                                "spacing": Object {
-                                  "baseUnit": 4,
-                                  "controlHeight": 38,
-                                  "menuGutter": 8,
-                                },
-                              }
-                            }
+                          <div
+                            className=" css-1gbz4ua"
                           >
-                            <EmotionCssPropInternal
-                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Placeholder"
-                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                              className=""
-                              css={
+                            <Placeholder
+                              clearValue={[Function]}
+                              cx={[Function]}
+                              getStyles={[Function]}
+                              getValue={[Function]}
+                              hasValue={false}
+                              isDisabled={false}
+                              isFocused={false}
+                              isMulti={false}
+                              isRtl={false}
+                              key="placeholder"
+                              options={Array []}
+                              selectOption={[Function]}
+                              selectProps={
                                 Object {
-                                  "boxSizing": "border-box",
-                                  "color": "hsl(0, 0%, 50%)",
-                                  "label": "placeholder",
-                                  "marginLeft": 2,
-                                  "marginRight": 2,
-                                  "position": "absolute",
-                                  "top": "50%",
-                                  "transform": "translateY(-50%)",
+                                  "backspaceRemovesValue": true,
+                                  "blurInputOnSelect": true,
+                                  "captureMenuScroll": false,
+                                  "closeMenuOnScroll": false,
+                                  "closeMenuOnSelect": true,
+                                  "components": Object {
+                                    "DropdownIndicator": [Function],
+                                    "Option": [Function],
+                                    "ValueContainer": [Function],
+                                  },
+                                  "controlShouldRenderValue": true,
+                                  "dropdownIcon": undefined,
+                                  "escapeClearsValue": false,
+                                  "filterOption": [Function],
+                                  "formatGroupLabel": [Function],
+                                  "getOptionLabel": [Function],
+                                  "getOptionValue": [Function],
+                                  "hideDropdownIcon": false,
+                                  "inputIcon": undefined,
+                                  "inputValue": "",
+                                  "isDisabled": false,
+                                  "isLoading": false,
+                                  "isMulti": false,
+                                  "isOptionDisabled": [Function],
+                                  "isRtl": false,
+                                  "isSearchable": true,
+                                  "loadingMessage": [Function],
+                                  "maxMenuHeight": 300,
+                                  "menuIsOpen": false,
+                                  "menuPlacement": "auto",
+                                  "menuPosition": "absolute",
+                                  "menuShouldBlockScroll": false,
+                                  "menuShouldScrollIntoView": true,
+                                  "minMenuHeight": 140,
+                                  "noOptionsMessage": [Function],
+                                  "onChange": [Function],
+                                  "onInputChange": [Function],
+                                  "onMenuClose": [Function],
+                                  "onMenuOpen": [Function],
+                                  "openMenuOnClick": true,
+                                  "openMenuOnFocus": false,
+                                  "options": Array [],
+                                  "pageSize": 5,
+                                  "placeholder": "Select...",
+                                  "screenReaderStatus": [Function],
+                                  "styles": Object {
+                                    "clearIndicator": [Function],
+                                    "container": [Function],
+                                    "control": [Function],
+                                    "dropdownIndicator": [Function],
+                                    "indicatorSeparator": [Function],
+                                    "indicatorsContainer": [Function],
+                                    "menu": [Function],
+                                    "menuList": [Function],
+                                    "menuPortal": [Function],
+                                    "option": [Function],
+                                    "singleValue": [Function],
+                                    "valueContainer": [Function],
+                                  },
+                                  "tabIndex": "0",
+                                  "tabSelectsValue": true,
+                                  "value": null,
+                                }
+                              }
+                              setValue={[Function]}
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(0, 0%, 100%)",
+                                    "neutral10": "hsl(0, 0%, 90%)",
+                                    "neutral20": "hsl(0, 0%, 80%)",
+                                    "neutral30": "hsl(0, 0%, 70%)",
+                                    "neutral40": "hsl(0, 0%, 60%)",
+                                    "neutral5": "hsl(0, 0%, 95%)",
+                                    "neutral50": "hsl(0, 0%, 50%)",
+                                    "neutral60": "hsl(0, 0%, 40%)",
+                                    "neutral70": "hsl(0, 0%, 30%)",
+                                    "neutral80": "hsl(0, 0%, 20%)",
+                                    "neutral90": "hsl(0, 0%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
                                 }
                               }
                             >
-                              <div
-                                className=" css-1wa3eu0-placeholder"
-                              >
-                                Select...
-                              </div>
-                            </EmotionCssPropInternal>
-                          </Placeholder>
-                          <Input
-                            aria-autocomplete="list"
-                            autoCapitalize="none"
-                            autoComplete="off"
-                            autoCorrect="off"
-                            cx={[Function]}
-                            getStyles={[Function]}
-                            id="react-select-2-input"
-                            innerRef={[Function]}
-                            isDisabled={false}
-                            isHidden={false}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            selectProps={
-                              Object {
-                                "backspaceRemovesValue": true,
-                                "blurInputOnSelect": true,
-                                "captureMenuScroll": false,
-                                "closeMenuOnScroll": false,
-                                "closeMenuOnSelect": true,
-                                "components": Object {
-                                  "Option": [Function],
-                                },
-                                "controlShouldRenderValue": true,
-                                "escapeClearsValue": false,
-                                "filterOption": [Function],
-                                "formatGroupLabel": [Function],
-                                "getOptionLabel": [Function],
-                                "getOptionValue": [Function],
-                                "icon": undefined,
-                                "inputValue": "",
-                                "isDisabled": false,
-                                "isLoading": false,
-                                "isMulti": false,
-                                "isOptionDisabled": [Function],
-                                "isRtl": false,
-                                "isSearchable": true,
-                                "loadingMessage": [Function],
-                                "maxMenuHeight": 300,
-                                "menuIsOpen": false,
-                                "menuPlacement": "auto",
-                                "menuPosition": "absolute",
-                                "menuShouldBlockScroll": false,
-                                "menuShouldScrollIntoView": true,
-                                "minMenuHeight": 140,
-                                "noOptionsMessage": [Function],
-                                "onChange": [Function],
-                                "onInputChange": [Function],
-                                "onMenuClose": [Function],
-                                "onMenuOpen": [Function],
-                                "openMenuOnClick": true,
-                                "openMenuOnFocus": false,
-                                "options": Array [],
-                                "pageSize": 5,
-                                "placeholder": "Select...",
-                                "screenReaderStatus": [Function],
-                                "styles": Object {
-                                  "clearIndicator": [Function],
-                                  "container": [Function],
-                                  "control": [Function],
-                                  "dropdownIndicator": [Function],
-                                  "indicatorSeparator": [Function],
-                                  "indicatorsContainer": [Function],
-                                  "menu": [Function],
-                                  "menuList": [Function],
-                                  "menuPortal": [Function],
-                                  "option": [Function],
-                                  "singleValue": [Function],
-                                  "valueContainer": [Function],
-                                },
-                                "tabIndex": "0",
-                                "tabSelectsValue": true,
-                                "value": null,
-                              }
-                            }
-                            spellCheck="false"
-                            tabIndex="0"
-                            theme={
-                              Object {
-                                "borderRadius": 4,
-                                "colors": Object {
-                                  "danger": "#DE350B",
-                                  "dangerLight": "#FFBDAD",
-                                  "neutral0": "hsl(0, 0%, 100%)",
-                                  "neutral10": "hsl(0, 0%, 90%)",
-                                  "neutral20": "hsl(0, 0%, 80%)",
-                                  "neutral30": "hsl(0, 0%, 70%)",
-                                  "neutral40": "hsl(0, 0%, 60%)",
-                                  "neutral5": "hsl(0, 0%, 95%)",
-                                  "neutral50": "hsl(0, 0%, 50%)",
-                                  "neutral60": "hsl(0, 0%, 40%)",
-                                  "neutral70": "hsl(0, 0%, 30%)",
-                                  "neutral80": "hsl(0, 0%, 20%)",
-                                  "neutral90": "hsl(0, 0%, 10%)",
-                                  "primary": "#2684FF",
-                                  "primary25": "#DEEBFF",
-                                  "primary50": "#B2D4FF",
-                                  "primary75": "#4C9AFF",
-                                },
-                                "spacing": Object {
-                                  "baseUnit": 4,
-                                  "controlHeight": 38,
-                                  "menuGutter": 8,
-                                },
-                              }
-                            }
-                            type="text"
-                            value=""
-                          >
-                            <EmotionCssPropInternal
-                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
-                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                              css={
-                                Object {
-                                  "boxSizing": "border-box",
-                                  "color": "hsl(0, 0%, 20%)",
-                                  "margin": 2,
-                                  "paddingBottom": 2,
-                                  "paddingTop": 2,
-                                  "visibility": "visible",
-                                }
-                              }
-                            >
-                              <div
-                                className="css-b8ldur-Input"
-                              >
-                                <AutosizeInput
-                                  aria-autocomplete="list"
-                                  autoCapitalize="none"
-                                  autoComplete="off"
-                                  autoCorrect="off"
-                                  className=""
-                                  disabled={false}
-                                  id="react-select-2-input"
-                                  injectStyles={true}
-                                  inputRef={[Function]}
-                                  inputStyle={
-                                    Object {
-                                      "background": 0,
-                                      "border": 0,
-                                      "color": "inherit",
-                                      "fontSize": "inherit",
-                                      "label": "input",
-                                      "opacity": 1,
-                                      "outline": 0,
-                                      "padding": 0,
-                                    }
+                              <EmotionCssPropInternal
+                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Placeholder"
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                className=""
+                                css={
+                                  Object {
+                                    "boxSizing": "border-box",
+                                    "color": "hsl(0, 0%, 50%)",
+                                    "label": "placeholder",
+                                    "marginLeft": 2,
+                                    "marginRight": 2,
+                                    "position": "absolute",
+                                    "top": "50%",
+                                    "transform": "translateY(-50%)",
                                   }
-                                  minWidth={1}
-                                  onBlur={[Function]}
-                                  onChange={[Function]}
-                                  onFocus={[Function]}
-                                  spellCheck="false"
-                                  tabIndex="0"
-                                  type="text"
-                                  value=""
+                                }
+                              >
+                                <div
+                                  className=" css-1wa3eu0-placeholder"
                                 >
-                                  <div
+                                  Select...
+                                </div>
+                              </EmotionCssPropInternal>
+                            </Placeholder>
+                            <Input
+                              aria-autocomplete="list"
+                              autoCapitalize="none"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              cx={[Function]}
+                              getStyles={[Function]}
+                              id="react-select-2-input"
+                              innerRef={[Function]}
+                              isDisabled={false}
+                              isHidden={false}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              selectProps={
+                                Object {
+                                  "backspaceRemovesValue": true,
+                                  "blurInputOnSelect": true,
+                                  "captureMenuScroll": false,
+                                  "closeMenuOnScroll": false,
+                                  "closeMenuOnSelect": true,
+                                  "components": Object {
+                                    "DropdownIndicator": [Function],
+                                    "Option": [Function],
+                                    "ValueContainer": [Function],
+                                  },
+                                  "controlShouldRenderValue": true,
+                                  "dropdownIcon": undefined,
+                                  "escapeClearsValue": false,
+                                  "filterOption": [Function],
+                                  "formatGroupLabel": [Function],
+                                  "getOptionLabel": [Function],
+                                  "getOptionValue": [Function],
+                                  "hideDropdownIcon": false,
+                                  "inputIcon": undefined,
+                                  "inputValue": "",
+                                  "isDisabled": false,
+                                  "isLoading": false,
+                                  "isMulti": false,
+                                  "isOptionDisabled": [Function],
+                                  "isRtl": false,
+                                  "isSearchable": true,
+                                  "loadingMessage": [Function],
+                                  "maxMenuHeight": 300,
+                                  "menuIsOpen": false,
+                                  "menuPlacement": "auto",
+                                  "menuPosition": "absolute",
+                                  "menuShouldBlockScroll": false,
+                                  "menuShouldScrollIntoView": true,
+                                  "minMenuHeight": 140,
+                                  "noOptionsMessage": [Function],
+                                  "onChange": [Function],
+                                  "onInputChange": [Function],
+                                  "onMenuClose": [Function],
+                                  "onMenuOpen": [Function],
+                                  "openMenuOnClick": true,
+                                  "openMenuOnFocus": false,
+                                  "options": Array [],
+                                  "pageSize": 5,
+                                  "placeholder": "Select...",
+                                  "screenReaderStatus": [Function],
+                                  "styles": Object {
+                                    "clearIndicator": [Function],
+                                    "container": [Function],
+                                    "control": [Function],
+                                    "dropdownIndicator": [Function],
+                                    "indicatorSeparator": [Function],
+                                    "indicatorsContainer": [Function],
+                                    "menu": [Function],
+                                    "menuList": [Function],
+                                    "menuPortal": [Function],
+                                    "option": [Function],
+                                    "singleValue": [Function],
+                                    "valueContainer": [Function],
+                                  },
+                                  "tabIndex": "0",
+                                  "tabSelectsValue": true,
+                                  "value": null,
+                                }
+                              }
+                              spellCheck="false"
+                              tabIndex="0"
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(0, 0%, 100%)",
+                                    "neutral10": "hsl(0, 0%, 90%)",
+                                    "neutral20": "hsl(0, 0%, 80%)",
+                                    "neutral30": "hsl(0, 0%, 70%)",
+                                    "neutral40": "hsl(0, 0%, 60%)",
+                                    "neutral5": "hsl(0, 0%, 95%)",
+                                    "neutral50": "hsl(0, 0%, 50%)",
+                                    "neutral60": "hsl(0, 0%, 40%)",
+                                    "neutral70": "hsl(0, 0%, 30%)",
+                                    "neutral80": "hsl(0, 0%, 20%)",
+                                    "neutral90": "hsl(0, 0%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
+                                }
+                              }
+                              type="text"
+                              value=""
+                            >
+                              <EmotionCssPropInternal
+                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                css={
+                                  Object {
+                                    "boxSizing": "border-box",
+                                    "color": "hsl(0, 0%, 20%)",
+                                    "margin": 2,
+                                    "paddingBottom": 2,
+                                    "paddingTop": 2,
+                                    "visibility": "visible",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="css-b8ldur-Input"
+                                >
+                                  <AutosizeInput
+                                    aria-autocomplete="list"
+                                    autoCapitalize="none"
+                                    autoComplete="off"
+                                    autoCorrect="off"
                                     className=""
-                                    style={
+                                    disabled={false}
+                                    id="react-select-2-input"
+                                    injectStyles={true}
+                                    inputRef={[Function]}
+                                    inputStyle={
                                       Object {
-                                        "display": "inline-block",
+                                        "background": 0,
+                                        "border": 0,
+                                        "color": "inherit",
+                                        "fontSize": "inherit",
+                                        "label": "input",
+                                        "opacity": 1,
+                                        "outline": 0,
+                                        "padding": 0,
                                       }
                                     }
+                                    minWidth={1}
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    spellCheck="false"
+                                    tabIndex="0"
+                                    type="text"
+                                    value=""
                                   >
-                                    <input
-                                      aria-autocomplete="list"
-                                      autoCapitalize="none"
-                                      autoComplete="off"
-                                      autoCorrect="off"
-                                      disabled={false}
-                                      id="react-select-2-input"
-                                      onBlur={[Function]}
-                                      onChange={[Function]}
-                                      onFocus={[Function]}
-                                      spellCheck="false"
-                                      style={
-                                        Object {
-                                          "background": 0,
-                                          "border": 0,
-                                          "boxSizing": "content-box",
-                                          "color": "inherit",
-                                          "fontSize": "inherit",
-                                          "label": "input",
-                                          "opacity": 1,
-                                          "outline": 0,
-                                          "padding": 0,
-                                          "width": "2px",
-                                        }
-                                      }
-                                      tabIndex="0"
-                                      type="text"
-                                      value=""
-                                    />
                                     <div
+                                      className=""
                                       style={
                                         Object {
-                                          "height": 0,
-                                          "left": 0,
-                                          "overflow": "scroll",
-                                          "position": "absolute",
-                                          "top": 0,
-                                          "visibility": "hidden",
-                                          "whiteSpace": "pre",
+                                          "display": "inline-block",
                                         }
                                       }
-                                    />
-                                  </div>
-                                </AutosizeInput>
-                              </div>
-                            </EmotionCssPropInternal>
-                          </Input>
-                        </div>
-                      </EmotionCssPropInternal>
+                                    >
+                                      <input
+                                        aria-autocomplete="list"
+                                        autoCapitalize="none"
+                                        autoComplete="off"
+                                        autoCorrect="off"
+                                        disabled={false}
+                                        id="react-select-2-input"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        spellCheck="false"
+                                        style={
+                                          Object {
+                                            "background": 0,
+                                            "border": 0,
+                                            "boxSizing": "content-box",
+                                            "color": "inherit",
+                                            "fontSize": "inherit",
+                                            "label": "input",
+                                            "opacity": 1,
+                                            "outline": 0,
+                                            "padding": 0,
+                                            "width": "2px",
+                                          }
+                                        }
+                                        tabIndex="0"
+                                        type="text"
+                                        value=""
+                                      />
+                                      <div
+                                        style={
+                                          Object {
+                                            "height": 0,
+                                            "left": 0,
+                                            "overflow": "scroll",
+                                            "position": "absolute",
+                                            "top": 0,
+                                            "visibility": "hidden",
+                                            "whiteSpace": "pre",
+                                          }
+                                        }
+                                      />
+                                    </div>
+                                  </AutosizeInput>
+                                </div>
+                              </EmotionCssPropInternal>
+                            </Input>
+                          </div>
+                        </EmotionCssPropInternal>
+                      </ValueContainer>
                     </ValueContainer>
                     <IndicatorsContainer
                       clearValue={[Function]}
@@ -874,15 +1012,19 @@ exports[`Select snapshot render matches snapshot 1`] = `
                           "closeMenuOnScroll": false,
                           "closeMenuOnSelect": true,
                           "components": Object {
+                            "DropdownIndicator": [Function],
                             "Option": [Function],
+                            "ValueContainer": [Function],
                           },
                           "controlShouldRenderValue": true,
+                          "dropdownIcon": undefined,
                           "escapeClearsValue": false,
                           "filterOption": [Function],
                           "formatGroupLabel": [Function],
                           "getOptionLabel": [Function],
                           "getOptionValue": [Function],
-                          "icon": undefined,
+                          "hideDropdownIcon": false,
+                          "inputIcon": undefined,
                           "inputValue": "",
                           "isDisabled": false,
                           "isLoading": false,
@@ -998,15 +1140,19 @@ exports[`Select snapshot render matches snapshot 1`] = `
                                 "closeMenuOnScroll": false,
                                 "closeMenuOnSelect": true,
                                 "components": Object {
+                                  "DropdownIndicator": [Function],
                                   "Option": [Function],
+                                  "ValueContainer": [Function],
                                 },
                                 "controlShouldRenderValue": true,
+                                "dropdownIcon": undefined,
                                 "escapeClearsValue": false,
                                 "filterOption": [Function],
                                 "formatGroupLabel": [Function],
                                 "getOptionLabel": [Function],
                                 "getOptionValue": [Function],
-                                "icon": undefined,
+                                "hideDropdownIcon": false,
+                                "inputIcon": undefined,
                                 "inputValue": "",
                                 "isDisabled": false,
                                 "isLoading": false,
@@ -1098,7 +1244,7 @@ exports[`Select snapshot render matches snapshot 1`] = `
                               />
                             </EmotionCssPropInternal>
                           </IndicatorSeparator>
-                          <DropdownIndicator
+                          <LUKDropdownIndicator
                             clearValue={[Function]}
                             cx={[Function]}
                             getStyles={[Function]}
@@ -1125,15 +1271,19 @@ exports[`Select snapshot render matches snapshot 1`] = `
                                 "closeMenuOnScroll": false,
                                 "closeMenuOnSelect": true,
                                 "components": Object {
+                                  "DropdownIndicator": [Function],
                                   "Option": [Function],
+                                  "ValueContainer": [Function],
                                 },
                                 "controlShouldRenderValue": true,
+                                "dropdownIcon": undefined,
                                 "escapeClearsValue": false,
                                 "filterOption": [Function],
                                 "formatGroupLabel": [Function],
                                 "getOptionLabel": [Function],
                                 "getOptionValue": [Function],
-                                "icon": undefined,
+                                "hideDropdownIcon": false,
+                                "inputIcon": undefined,
                                 "inputValue": "",
                                 "isDisabled": false,
                                 "isLoading": false,
@@ -1210,66 +1360,183 @@ exports[`Select snapshot render matches snapshot 1`] = `
                               }
                             }
                           >
-                            <EmotionCssPropInternal
-                              __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
-                              __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                              aria-hidden="true"
-                              className=""
-                              css={
+                            <DropdownIndicator
+                              clearValue={[Function]}
+                              cx={[Function]}
+                              getStyles={[Function]}
+                              getValue={[Function]}
+                              hasValue={false}
+                              innerProps={
                                 Object {
-                                  "color": "#b6bbc7",
-                                  "display": "flex",
-                                  "margin": "5px",
-                                  "padding": "0",
+                                  "aria-hidden": "true",
+                                  "onMouseDown": [Function],
+                                  "onTouchEnd": [Function],
                                 }
                               }
-                              onMouseDown={[Function]}
-                              onTouchEnd={[Function]}
+                              isDisabled={false}
+                              isFocused={false}
+                              isMulti={false}
+                              isRtl={false}
+                              options={Array []}
+                              selectOption={[Function]}
+                              selectProps={
+                                Object {
+                                  "backspaceRemovesValue": true,
+                                  "blurInputOnSelect": true,
+                                  "captureMenuScroll": false,
+                                  "closeMenuOnScroll": false,
+                                  "closeMenuOnSelect": true,
+                                  "components": Object {
+                                    "DropdownIndicator": [Function],
+                                    "Option": [Function],
+                                    "ValueContainer": [Function],
+                                  },
+                                  "controlShouldRenderValue": true,
+                                  "dropdownIcon": undefined,
+                                  "escapeClearsValue": false,
+                                  "filterOption": [Function],
+                                  "formatGroupLabel": [Function],
+                                  "getOptionLabel": [Function],
+                                  "getOptionValue": [Function],
+                                  "hideDropdownIcon": false,
+                                  "inputIcon": undefined,
+                                  "inputValue": "",
+                                  "isDisabled": false,
+                                  "isLoading": false,
+                                  "isMulti": false,
+                                  "isOptionDisabled": [Function],
+                                  "isRtl": false,
+                                  "isSearchable": true,
+                                  "loadingMessage": [Function],
+                                  "maxMenuHeight": 300,
+                                  "menuIsOpen": false,
+                                  "menuPlacement": "auto",
+                                  "menuPosition": "absolute",
+                                  "menuShouldBlockScroll": false,
+                                  "menuShouldScrollIntoView": true,
+                                  "minMenuHeight": 140,
+                                  "noOptionsMessage": [Function],
+                                  "onChange": [Function],
+                                  "onInputChange": [Function],
+                                  "onMenuClose": [Function],
+                                  "onMenuOpen": [Function],
+                                  "openMenuOnClick": true,
+                                  "openMenuOnFocus": false,
+                                  "options": Array [],
+                                  "pageSize": 5,
+                                  "placeholder": "Select...",
+                                  "screenReaderStatus": [Function],
+                                  "styles": Object {
+                                    "clearIndicator": [Function],
+                                    "container": [Function],
+                                    "control": [Function],
+                                    "dropdownIndicator": [Function],
+                                    "indicatorSeparator": [Function],
+                                    "indicatorsContainer": [Function],
+                                    "menu": [Function],
+                                    "menuList": [Function],
+                                    "menuPortal": [Function],
+                                    "option": [Function],
+                                    "singleValue": [Function],
+                                    "valueContainer": [Function],
+                                  },
+                                  "tabIndex": "0",
+                                  "tabSelectsValue": true,
+                                  "value": null,
+                                }
+                              }
+                              setValue={[Function]}
+                              theme={
+                                Object {
+                                  "borderRadius": 4,
+                                  "colors": Object {
+                                    "danger": "#DE350B",
+                                    "dangerLight": "#FFBDAD",
+                                    "neutral0": "hsl(0, 0%, 100%)",
+                                    "neutral10": "hsl(0, 0%, 90%)",
+                                    "neutral20": "hsl(0, 0%, 80%)",
+                                    "neutral30": "hsl(0, 0%, 70%)",
+                                    "neutral40": "hsl(0, 0%, 60%)",
+                                    "neutral5": "hsl(0, 0%, 95%)",
+                                    "neutral50": "hsl(0, 0%, 50%)",
+                                    "neutral60": "hsl(0, 0%, 40%)",
+                                    "neutral70": "hsl(0, 0%, 30%)",
+                                    "neutral80": "hsl(0, 0%, 20%)",
+                                    "neutral90": "hsl(0, 0%, 10%)",
+                                    "primary": "#2684FF",
+                                    "primary25": "#DEEBFF",
+                                    "primary50": "#B2D4FF",
+                                    "primary75": "#4C9AFF",
+                                  },
+                                  "spacing": Object {
+                                    "baseUnit": 4,
+                                    "controlHeight": 38,
+                                    "menuGutter": 8,
+                                  },
+                                }
+                              }
                             >
-                              <div
+                              <EmotionCssPropInternal
+                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
+                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
                                 aria-hidden="true"
-                                className=" css-1vd5qh6-DropdownIndicator"
+                                className=""
+                                css={
+                                  Object {
+                                    "color": "#b6bbc7",
+                                    "display": "flex",
+                                    "margin": "5px",
+                                    "padding": "0",
+                                  }
+                                }
                                 onMouseDown={[Function]}
                                 onTouchEnd={[Function]}
                               >
-                                <DownChevron>
-                                  <Svg
-                                    size={20}
-                                  >
-                                    <EmotionCssPropInternal
-                                      __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
-                                      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
-                                      aria-hidden="true"
-                                      css={
-                                        Object {
-                                          "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
-                                          "name": "19bqh2r",
-                                          "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
-                                        }
-                                      }
-                                      focusable="false"
-                                      height={20}
-                                      viewBox="0 0 20 20"
-                                      width={20}
+                                <div
+                                  aria-hidden="true"
+                                  className=" css-1vd5qh6-DropdownIndicator"
+                                  onMouseDown={[Function]}
+                                  onTouchEnd={[Function]}
+                                >
+                                  <DownChevron>
+                                    <Svg
+                                      size={20}
                                     >
-                                      <svg
+                                      <EmotionCssPropInternal
+                                        __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
+                                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
                                         aria-hidden="true"
-                                        className="css-6q0nyr-Svg"
+                                        css={
+                                          Object {
+                                            "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
+                                            "name": "19bqh2r",
+                                            "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
+                                          }
+                                        }
                                         focusable="false"
                                         height={20}
                                         viewBox="0 0 20 20"
                                         width={20}
                                       >
-                                        <path
-                                          d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                                        />
-                                      </svg>
-                                    </EmotionCssPropInternal>
-                                  </Svg>
-                                </DownChevron>
-                              </div>
-                            </EmotionCssPropInternal>
-                          </DropdownIndicator>
+                                        <svg
+                                          aria-hidden="true"
+                                          className="css-6q0nyr-Svg"
+                                          focusable="false"
+                                          height={20}
+                                          viewBox="0 0 20 20"
+                                          width={20}
+                                        >
+                                          <path
+                                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                          />
+                                        </svg>
+                                      </EmotionCssPropInternal>
+                                    </Svg>
+                                  </DownChevron>
+                                </div>
+                              </EmotionCssPropInternal>
+                            </DropdownIndicator>
+                          </LUKDropdownIndicator>
                         </div>
                       </EmotionCssPropInternal>
                     </IndicatorsContainer>

--- a/src/select/src/components/__snapshots__/SelectController.test.js.snap
+++ b/src/select/src/components/__snapshots__/SelectController.test.js.snap
@@ -5,12 +5,15 @@ exports[`Select snapshot render matches snapshot 1`] = `
   <StateManager
     components={
       Object {
+        "DropdownIndicator": [Function],
         "Option": [Function],
+        "ValueContainer": [Function],
       }
     }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}
+    hideDropdownIcon={false}
   />
 </Fragment>
 `;

--- a/src/select/src/components/styled/DropdownIndicator.js
+++ b/src/select/src/components/styled/DropdownIndicator.js
@@ -2,38 +2,41 @@
  * @flow
  */
 
-import React, { Component } from 'react';
-import type { ElementConfig, Element } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+import type { ElementConfig } from 'react';
 
+import isPlainObject from 'lodash/isPlainObject';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { components } from 'react-select';
 
 const { DropdownIndicator: RSDropdownIndicator } = components;
 
 type Props = ElementConfig<typeof RSDropdownIndicator>;
 
+const LUKDropdownIndicator = (props :Props) => {
 
-class DropdownIndicator extends Component<Props> {
+  const { selectProps: { dropdownIcon, icon, hideDropdownIcon } } = props;
 
-  renderIcon = () :Element<any> => {
-    const { selectProps: { icon } } = this.props;
+  if (hideDropdownIcon) return null;
 
-    if (typeof icon === 'function') {
-      return icon();
-    }
-
-    return <FontAwesomeIcon icon={icon} fixedWidth />;
+  if (icon) {
+    console.warn('lattice-ui-kit Select: \'icon\' prop is deprecated. Use \'dropdownIcon\' which accepts React.Node.');
   }
 
-  render() {
-    /* eslint-disable react/jsx-props-no-spreading */
-    return (
-      <RSDropdownIndicator {...this.props}>
-        { this.renderIcon() }
-      </RSDropdownIndicator>
-    );
-    /* eslint-enable */
+  let finalIcon = dropdownIcon || icon;
+  if (typeof icon === 'function') {
+    finalIcon = icon();
   }
-}
+  else if (isPlainObject(icon)) {
+    finalIcon = <FontAwesomeIcon icon={icon} fixedWidth />;
+  }
 
-export default DropdownIndicator;
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <RSDropdownIndicator {...props}>
+      { finalIcon }
+    </RSDropdownIndicator>
+  );
+};
+
+export default LUKDropdownIndicator;

--- a/src/select/src/components/styled/ValueContainer.js
+++ b/src/select/src/components/styled/ValueContainer.js
@@ -1,0 +1,41 @@
+// @flow
+import React from 'react';
+import type { ElementConfig } from 'react';
+
+import styled from 'styled-components';
+import { components } from 'react-select';
+
+import { NEUTRALS } from '../../../../colors';
+
+const IconWrapper = styled.span`
+  position: absolute;
+  left: 12px;
+  color: ${NEUTRALS[2]};
+`;
+
+type Props = ElementConfig<typeof components.ValueContainer>;
+
+const ValueContainer = ({ children, selectProps, ...props } :Props) => {
+  const { inputIcon } = selectProps;
+  return (
+    components.ValueContainer && (
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <components.ValueContainer selectProps={selectProps} {...props}>
+        {
+          inputIcon && (
+            <IconWrapper>
+              {inputIcon}
+            </IconWrapper>
+          )
+        }
+        {children}
+      </components.ValueContainer>
+    )
+  );
+};
+
+ValueContainer.defaultProps = {
+  inputIcon: null
+};
+
+export default ValueContainer;

--- a/src/select/stories/index.stories.js
+++ b/src/select/stories/index.stories.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
+
+import { faSearch } from '@fortawesome/pro-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faNarwhal } from '@fortawesome/pro-regular-svg-icons';
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 
-import { Select, Creatable, CheckboxSelect } from '../index';
-import { paragraph, stateOptions, REACT_SELECT_USAGE } from './constants';
+import { REACT_SELECT_USAGE, paragraph, stateOptions } from './constants';
+
 import { genRealWordSelectOptions } from '../../utils/testing/MockUtils';
-
-const customIcon = () => <FontAwesomeIcon icon={faNarwhal} spin />;
+import { CheckboxSelect, Creatable, Select } from '../index';
 
 const stressTestWordOptions = genRealWordSelectOptions(paragraph);
 
@@ -91,34 +91,28 @@ storiesOf('Select', module)
   ))
   .add('Appearances', () => (
     <>
-      <h1>borderless</h1>
+      <h2>borderless</h2>
       <p>Default background-color is transparent</p>
       <Select
           borderless
-          options={stateOptions}
-          onChange={action('Borderless changed')} />
-      <h1>invalid</h1>
+          options={stateOptions} />
+      <h2>invalid</h2>
       <p>border is red</p>
       <Select
           invalid
-          options={stateOptions}
-          onChange={action('Borderless changed')} />
-    </>
-  ))
-  .add('custom dropdown indicator', () => (
-    <>
-      <h1>Custom Dropdown Indicator</h1>
-      <h2>FontAwesome IconDefinition</h2>
+          options={stateOptions} />
+      <h2>inputIcon</h2>
       <Select
-          icon={faNarwhal}
-          options={stateOptions}
-          onChange={action('Single select changed')} />
-      <h2>Custom Icon</h2>
+          inputIcon={<FontAwesomeIcon icon={faSearch} fixedWidth />}
+          options={stateOptions} />
+      <h2>dropdownIcon</h2>
       <Select
-          icon={customIcon}
-          useRawValues
-          options={stateOptions}
-          onChange={action('Single select changed')} />
+          dropdownIcon={<FontAwesomeIcon icon={faSearch} fixedWidth />}
+          options={stateOptions} />
+      <h2>hideDropdownIcon</h2>
+      <Select
+          hideDropdownIcon
+          options={stateOptions} />
     </>
   ))
   .add('Disabled options', () => (

--- a/src/style/select/optionStyles.js
+++ b/src/style/select/optionStyles.js
@@ -27,6 +27,7 @@ const optionStyles = (base, state) => {
 
   let style = {
     color,
+    fontSize: '0.875rem',
     backgroundColor,
     ':active': {
       backgroundColor: activeBgColor,

--- a/src/style/select/valueContainerStyles.js
+++ b/src/style/select/valueContainerStyles.js
@@ -1,2 +1,11 @@
-const valueContainerStyles = (base) => ({ ...base, padding: '0 10px' });
+const valueContainerStyles = (base, state) => {
+  const { selectProps } = state;
+  let padding = '0 10px';
+
+  if (selectProps && selectProps.inputIcon) {
+    padding = '0 10px 0 34px';
+  }
+
+  return { ...base, padding };
+};
 export default valueContainerStyles;

--- a/src/table/src/components/__snapshots__/Table.test.js.snap
+++ b/src/table/src/components/__snapshots__/Table.test.js.snap
@@ -4893,6 +4893,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           "value": 5,
                         }
                       }
+                      hideDropdownIcon={false}
                       onChange={[Function]}
                       options={
                         Array [
@@ -4918,7 +4919,9 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                         borderless={true}
                         components={
                           Object {
+                            "DropdownIndicator": [Function],
                             "Option": [Function],
+                            "ValueContainer": [Function],
                           }
                         }
                         defaultInputValue=""
@@ -4930,6 +4933,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           }
                         }
                         filterOption={[Function]}
+                        hideDropdownIcon={false}
                         menuPlacement="auto"
                         onChange={[Function]}
                         options={
@@ -4980,7 +4984,9 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           closeMenuOnSelect={true}
                           components={
                             Object {
+                              "DropdownIndicator": [Function],
                               "Option": [Function],
+                              "ValueContainer": [Function],
                             }
                           }
                           controlShouldRenderValue={true}
@@ -4989,6 +4995,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           formatGroupLabel={[Function]}
                           getOptionLabel={[Function]}
                           getOptionValue={[Function]}
+                          hideDropdownIcon={false}
                           inputValue=""
                           isDisabled={false}
                           isLoading={false}
@@ -5097,15 +5104,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                 "closeMenuOnScroll": false,
                                 "closeMenuOnSelect": true,
                                 "components": Object {
+                                  "DropdownIndicator": [Function],
                                   "Option": [Function],
+                                  "ValueContainer": [Function],
                                 },
                                 "controlShouldRenderValue": true,
+                                "dropdownIcon": undefined,
                                 "escapeClearsValue": false,
                                 "filterOption": [Function],
                                 "formatGroupLabel": [Function],
                                 "getOptionLabel": [Function],
                                 "getOptionValue": [Function],
-                                "icon": undefined,
+                                "hideDropdownIcon": false,
+                                "inputIcon": undefined,
                                 "inputValue": "",
                                 "isDisabled": false,
                                 "isLoading": false,
@@ -5263,15 +5274,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                       "closeMenuOnScroll": false,
                                       "closeMenuOnSelect": true,
                                       "components": Object {
+                                        "DropdownIndicator": [Function],
                                         "Option": [Function],
+                                        "ValueContainer": [Function],
                                       },
                                       "controlShouldRenderValue": true,
+                                      "dropdownIcon": undefined,
                                       "escapeClearsValue": false,
                                       "filterOption": [Function],
                                       "formatGroupLabel": [Function],
                                       "getOptionLabel": [Function],
                                       "getOptionValue": [Function],
-                                      "icon": undefined,
+                                      "hideDropdownIcon": false,
+                                      "inputIcon": undefined,
                                       "inputValue": "",
                                       "isDisabled": false,
                                       "isLoading": false,
@@ -5414,6 +5429,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                         getStyles={[Function]}
                                         getValue={[Function]}
                                         hasValue={true}
+                                        inputIcon={null}
                                         isDisabled={false}
                                         isMulti={false}
                                         isRtl={false}
@@ -5443,15 +5459,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                             "closeMenuOnScroll": false,
                                             "closeMenuOnSelect": true,
                                             "components": Object {
+                                              "DropdownIndicator": [Function],
                                               "Option": [Function],
+                                              "ValueContainer": [Function],
                                             },
                                             "controlShouldRenderValue": true,
+                                            "dropdownIcon": undefined,
                                             "escapeClearsValue": false,
                                             "filterOption": [Function],
                                             "formatGroupLabel": [Function],
                                             "getOptionLabel": [Function],
                                             "getOptionValue": [Function],
-                                            "icon": undefined,
+                                            "hideDropdownIcon": false,
+                                            "inputIcon": undefined,
                                             "inputValue": "",
                                             "isDisabled": false,
                                             "isLoading": false,
@@ -5544,99 +5564,184 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                           }
                                         }
                                       >
-                                        <EmotionCssPropInternal
-                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                          className=""
-                                          css={
-                                            Object {
-                                              "WebkitOverflowScrolling": "touch",
-                                              "alignItems": "center",
-                                              "boxSizing": "border-box",
-                                              "display": "flex",
-                                              "flex": 1,
-                                              "flexWrap": "wrap",
-                                              "overflow": "hidden",
-                                              "padding": "0 10px",
-                                              "position": "relative",
-                                            }
+                                        <ValueContainer
+                                          clearValue={[Function]}
+                                          cx={[Function]}
+                                          getStyles={[Function]}
+                                          getValue={[Function]}
+                                          hasValue={true}
+                                          inputIcon={null}
+                                          isDisabled={false}
+                                          isMulti={false}
+                                          isRtl={false}
+                                          options={
+                                            Array [
+                                              Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                              Object {
+                                                "label": "20",
+                                                "value": 20,
+                                              },
+                                              Object {
+                                                "label": "50",
+                                                "value": 50,
+                                              },
+                                            ]
                                           }
-                                        >
-                                          <div
-                                            className=" css-1gbz4ua"
-                                          >
-                                            <SingleValue
-                                              clearValue={[Function]}
-                                              cx={[Function]}
-                                              data={
+                                          selectOption={[Function]}
+                                          selectProps={
+                                            Object {
+                                              "backspaceRemovesValue": true,
+                                              "blurInputOnSelect": true,
+                                              "borderless": true,
+                                              "captureMenuScroll": false,
+                                              "closeMenuOnScroll": false,
+                                              "closeMenuOnSelect": true,
+                                              "components": Object {
+                                                "DropdownIndicator": [Function],
+                                                "Option": [Function],
+                                                "ValueContainer": [Function],
+                                              },
+                                              "controlShouldRenderValue": true,
+                                              "dropdownIcon": undefined,
+                                              "escapeClearsValue": false,
+                                              "filterOption": [Function],
+                                              "formatGroupLabel": [Function],
+                                              "getOptionLabel": [Function],
+                                              "getOptionValue": [Function],
+                                              "hideDropdownIcon": false,
+                                              "inputIcon": undefined,
+                                              "inputValue": "",
+                                              "isDisabled": false,
+                                              "isLoading": false,
+                                              "isMulti": false,
+                                              "isOptionDisabled": [Function],
+                                              "isRtl": false,
+                                              "isSearchable": true,
+                                              "loadingMessage": [Function],
+                                              "maxMenuHeight": 300,
+                                              "menuIsOpen": false,
+                                              "menuPlacement": "auto",
+                                              "menuPosition": "absolute",
+                                              "menuShouldBlockScroll": false,
+                                              "menuShouldScrollIntoView": true,
+                                              "minMenuHeight": 140,
+                                              "noOptionsMessage": [Function],
+                                              "onChange": [Function],
+                                              "onInputChange": [Function],
+                                              "onMenuClose": [Function],
+                                              "onMenuOpen": [Function],
+                                              "openMenuOnClick": true,
+                                              "openMenuOnFocus": false,
+                                              "options": Array [
                                                 Object {
                                                   "label": "5",
                                                   "value": 5,
-                                                }
+                                                },
+                                                Object {
+                                                  "label": "20",
+                                                  "value": 20,
+                                                },
+                                                Object {
+                                                  "label": "50",
+                                                  "value": 50,
+                                                },
+                                              ],
+                                              "pageSize": 5,
+                                              "placeholder": "Select...",
+                                              "screenReaderStatus": [Function],
+                                              "styles": Object {
+                                                "clearIndicator": [Function],
+                                                "container": [Function],
+                                                "control": [Function],
+                                                "dropdownIndicator": [Function],
+                                                "indicatorSeparator": [Function],
+                                                "indicatorsContainer": [Function],
+                                                "menu": [Function],
+                                                "menuList": [Function],
+                                                "menuPortal": [Function],
+                                                "option": [Function],
+                                                "singleValue": [Function],
+                                                "valueContainer": [Function],
+                                              },
+                                              "tabIndex": "0",
+                                              "tabSelectsValue": true,
+                                              "value": Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                            }
+                                          }
+                                          setValue={[Function]}
+                                          theme={
+                                            Object {
+                                              "borderRadius": 4,
+                                              "colors": Object {
+                                                "danger": "#DE350B",
+                                                "dangerLight": "#FFBDAD",
+                                                "neutral0": "hsl(0, 0%, 100%)",
+                                                "neutral10": "hsl(0, 0%, 90%)",
+                                                "neutral20": "hsl(0, 0%, 80%)",
+                                                "neutral30": "hsl(0, 0%, 70%)",
+                                                "neutral40": "hsl(0, 0%, 60%)",
+                                                "neutral5": "hsl(0, 0%, 95%)",
+                                                "neutral50": "hsl(0, 0%, 50%)",
+                                                "neutral60": "hsl(0, 0%, 40%)",
+                                                "neutral70": "hsl(0, 0%, 30%)",
+                                                "neutral80": "hsl(0, 0%, 20%)",
+                                                "neutral90": "hsl(0, 0%, 10%)",
+                                                "primary": "#2684FF",
+                                                "primary25": "#DEEBFF",
+                                                "primary50": "#B2D4FF",
+                                                "primary75": "#4C9AFF",
+                                              },
+                                              "spacing": Object {
+                                                "baseUnit": 4,
+                                                "controlHeight": 38,
+                                                "menuGutter": 8,
+                                              },
+                                            }
+                                          }
+                                        >
+                                          <EmotionCssPropInternal
+                                            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                            className=""
+                                            css={
+                                              Object {
+                                                "WebkitOverflowScrolling": "touch",
+                                                "alignItems": "center",
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexWrap": "wrap",
+                                                "overflow": "hidden",
+                                                "padding": "0 10px",
+                                                "position": "relative",
                                               }
-                                              getStyles={[Function]}
-                                              getValue={[Function]}
-                                              hasValue={true}
-                                              isDisabled={false}
-                                              isMulti={false}
-                                              isRtl={false}
-                                              options={
-                                                Array [
+                                            }
+                                          >
+                                            <div
+                                              className=" css-1gbz4ua"
+                                            >
+                                              <SingleValue
+                                                clearValue={[Function]}
+                                                cx={[Function]}
+                                                data={
                                                   Object {
                                                     "label": "5",
                                                     "value": 5,
-                                                  },
-                                                  Object {
-                                                    "label": "20",
-                                                    "value": 20,
-                                                  },
-                                                  Object {
-                                                    "label": "50",
-                                                    "value": 50,
-                                                  },
-                                                ]
-                                              }
-                                              selectOption={[Function]}
-                                              selectProps={
-                                                Object {
-                                                  "backspaceRemovesValue": true,
-                                                  "blurInputOnSelect": true,
-                                                  "borderless": true,
-                                                  "captureMenuScroll": false,
-                                                  "closeMenuOnScroll": false,
-                                                  "closeMenuOnSelect": true,
-                                                  "components": Object {
-                                                    "Option": [Function],
-                                                  },
-                                                  "controlShouldRenderValue": true,
-                                                  "escapeClearsValue": false,
-                                                  "filterOption": [Function],
-                                                  "formatGroupLabel": [Function],
-                                                  "getOptionLabel": [Function],
-                                                  "getOptionValue": [Function],
-                                                  "icon": undefined,
-                                                  "inputValue": "",
-                                                  "isDisabled": false,
-                                                  "isLoading": false,
-                                                  "isMulti": false,
-                                                  "isOptionDisabled": [Function],
-                                                  "isRtl": false,
-                                                  "isSearchable": true,
-                                                  "loadingMessage": [Function],
-                                                  "maxMenuHeight": 300,
-                                                  "menuIsOpen": false,
-                                                  "menuPlacement": "auto",
-                                                  "menuPosition": "absolute",
-                                                  "menuShouldBlockScroll": false,
-                                                  "menuShouldScrollIntoView": true,
-                                                  "minMenuHeight": 140,
-                                                  "noOptionsMessage": [Function],
-                                                  "onChange": [Function],
-                                                  "onInputChange": [Function],
-                                                  "onMenuClose": [Function],
-                                                  "onMenuOpen": [Function],
-                                                  "openMenuOnClick": true,
-                                                  "openMenuOnFocus": false,
-                                                  "options": Array [
+                                                  }
+                                                }
+                                                getStyles={[Function]}
+                                                getValue={[Function]}
+                                                hasValue={true}
+                                                isDisabled={false}
+                                                isMulti={false}
+                                                isRtl={false}
+                                                options={
+                                                  Array [
                                                     Object {
                                                       "label": "5",
                                                       "value": 5,
@@ -5649,323 +5754,388 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                       "label": "50",
                                                       "value": 50,
                                                     },
-                                                  ],
-                                                  "pageSize": 5,
-                                                  "placeholder": "Select...",
-                                                  "screenReaderStatus": [Function],
-                                                  "styles": Object {
-                                                    "clearIndicator": [Function],
-                                                    "container": [Function],
-                                                    "control": [Function],
-                                                    "dropdownIndicator": [Function],
-                                                    "indicatorSeparator": [Function],
-                                                    "indicatorsContainer": [Function],
-                                                    "menu": [Function],
-                                                    "menuList": [Function],
-                                                    "menuPortal": [Function],
-                                                    "option": [Function],
-                                                    "singleValue": [Function],
-                                                    "valueContainer": [Function],
-                                                  },
-                                                  "tabIndex": "0",
-                                                  "tabSelectsValue": true,
-                                                  "value": Object {
-                                                    "label": "5",
-                                                    "value": 5,
-                                                  },
+                                                  ]
                                                 }
-                                              }
-                                              setValue={[Function]}
-                                              theme={
-                                                Object {
-                                                  "borderRadius": 4,
-                                                  "colors": Object {
-                                                    "danger": "#DE350B",
-                                                    "dangerLight": "#FFBDAD",
-                                                    "neutral0": "hsl(0, 0%, 100%)",
-                                                    "neutral10": "hsl(0, 0%, 90%)",
-                                                    "neutral20": "hsl(0, 0%, 80%)",
-                                                    "neutral30": "hsl(0, 0%, 70%)",
-                                                    "neutral40": "hsl(0, 0%, 60%)",
-                                                    "neutral5": "hsl(0, 0%, 95%)",
-                                                    "neutral50": "hsl(0, 0%, 50%)",
-                                                    "neutral60": "hsl(0, 0%, 40%)",
-                                                    "neutral70": "hsl(0, 0%, 30%)",
-                                                    "neutral80": "hsl(0, 0%, 20%)",
-                                                    "neutral90": "hsl(0, 0%, 10%)",
-                                                    "primary": "#2684FF",
-                                                    "primary25": "#DEEBFF",
-                                                    "primary50": "#B2D4FF",
-                                                    "primary75": "#4C9AFF",
-                                                  },
-                                                  "spacing": Object {
-                                                    "baseUnit": 4,
-                                                    "controlHeight": 38,
-                                                    "menuGutter": 8,
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              <EmotionCssPropInternal
-                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SingleValue"
-                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                                className=""
-                                                css={
+                                                selectOption={[Function]}
+                                                selectProps={
                                                   Object {
-                                                    "boxSizing": "border-box",
-                                                    "color": "inherit",
-                                                    "label": "singleValue",
-                                                    "marginLeft": 2,
-                                                    "marginRight": 2,
-                                                    "maxWidth": "calc(100% - 8px)",
-                                                    "overflow": "hidden",
-                                                    "position": "absolute",
-                                                    "textOverflow": "ellipsis",
-                                                    "top": "50%",
-                                                    "transform": "translateY(-50%)",
-                                                    "whiteSpace": "nowrap",
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className=" css-1xqm9c7-singleValue"
-                                                >
-                                                  5
-                                                </div>
-                                              </EmotionCssPropInternal>
-                                            </SingleValue>
-                                            <Input
-                                              aria-autocomplete="list"
-                                              autoCapitalize="none"
-                                              autoComplete="off"
-                                              autoCorrect="off"
-                                              cx={[Function]}
-                                              getStyles={[Function]}
-                                              id="react-select-2-input"
-                                              innerRef={[Function]}
-                                              isDisabled={false}
-                                              isHidden={false}
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              selectProps={
-                                                Object {
-                                                  "backspaceRemovesValue": true,
-                                                  "blurInputOnSelect": true,
-                                                  "borderless": true,
-                                                  "captureMenuScroll": false,
-                                                  "closeMenuOnScroll": false,
-                                                  "closeMenuOnSelect": true,
-                                                  "components": Object {
-                                                    "Option": [Function],
-                                                  },
-                                                  "controlShouldRenderValue": true,
-                                                  "escapeClearsValue": false,
-                                                  "filterOption": [Function],
-                                                  "formatGroupLabel": [Function],
-                                                  "getOptionLabel": [Function],
-                                                  "getOptionValue": [Function],
-                                                  "icon": undefined,
-                                                  "inputValue": "",
-                                                  "isDisabled": false,
-                                                  "isLoading": false,
-                                                  "isMulti": false,
-                                                  "isOptionDisabled": [Function],
-                                                  "isRtl": false,
-                                                  "isSearchable": true,
-                                                  "loadingMessage": [Function],
-                                                  "maxMenuHeight": 300,
-                                                  "menuIsOpen": false,
-                                                  "menuPlacement": "auto",
-                                                  "menuPosition": "absolute",
-                                                  "menuShouldBlockScroll": false,
-                                                  "menuShouldScrollIntoView": true,
-                                                  "minMenuHeight": 140,
-                                                  "noOptionsMessage": [Function],
-                                                  "onChange": [Function],
-                                                  "onInputChange": [Function],
-                                                  "onMenuClose": [Function],
-                                                  "onMenuOpen": [Function],
-                                                  "openMenuOnClick": true,
-                                                  "openMenuOnFocus": false,
-                                                  "options": Array [
-                                                    Object {
-                                                      "label": "5",
-                                                      "value": 5,
+                                                    "backspaceRemovesValue": true,
+                                                    "blurInputOnSelect": true,
+                                                    "borderless": true,
+                                                    "captureMenuScroll": false,
+                                                    "closeMenuOnScroll": false,
+                                                    "closeMenuOnSelect": true,
+                                                    "components": Object {
+                                                      "DropdownIndicator": [Function],
+                                                      "Option": [Function],
+                                                      "ValueContainer": [Function],
                                                     },
-                                                    Object {
-                                                      "label": "20",
-                                                      "value": 20,
-                                                    },
-                                                    Object {
-                                                      "label": "50",
-                                                      "value": 50,
-                                                    },
-                                                  ],
-                                                  "pageSize": 5,
-                                                  "placeholder": "Select...",
-                                                  "screenReaderStatus": [Function],
-                                                  "styles": Object {
-                                                    "clearIndicator": [Function],
-                                                    "container": [Function],
-                                                    "control": [Function],
-                                                    "dropdownIndicator": [Function],
-                                                    "indicatorSeparator": [Function],
-                                                    "indicatorsContainer": [Function],
-                                                    "menu": [Function],
-                                                    "menuList": [Function],
-                                                    "menuPortal": [Function],
-                                                    "option": [Function],
-                                                    "singleValue": [Function],
-                                                    "valueContainer": [Function],
-                                                  },
-                                                  "tabIndex": "0",
-                                                  "tabSelectsValue": true,
-                                                  "value": Object {
-                                                    "label": "5",
-                                                    "value": 5,
-                                                  },
-                                                }
-                                              }
-                                              spellCheck="false"
-                                              tabIndex="0"
-                                              theme={
-                                                Object {
-                                                  "borderRadius": 4,
-                                                  "colors": Object {
-                                                    "danger": "#DE350B",
-                                                    "dangerLight": "#FFBDAD",
-                                                    "neutral0": "hsl(0, 0%, 100%)",
-                                                    "neutral10": "hsl(0, 0%, 90%)",
-                                                    "neutral20": "hsl(0, 0%, 80%)",
-                                                    "neutral30": "hsl(0, 0%, 70%)",
-                                                    "neutral40": "hsl(0, 0%, 60%)",
-                                                    "neutral5": "hsl(0, 0%, 95%)",
-                                                    "neutral50": "hsl(0, 0%, 50%)",
-                                                    "neutral60": "hsl(0, 0%, 40%)",
-                                                    "neutral70": "hsl(0, 0%, 30%)",
-                                                    "neutral80": "hsl(0, 0%, 20%)",
-                                                    "neutral90": "hsl(0, 0%, 10%)",
-                                                    "primary": "#2684FF",
-                                                    "primary25": "#DEEBFF",
-                                                    "primary50": "#B2D4FF",
-                                                    "primary75": "#4C9AFF",
-                                                  },
-                                                  "spacing": Object {
-                                                    "baseUnit": 4,
-                                                    "controlHeight": 38,
-                                                    "menuGutter": 8,
-                                                  },
-                                                }
-                                              }
-                                              type="text"
-                                              value=""
-                                            >
-                                              <EmotionCssPropInternal
-                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
-                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                                css={
-                                                  Object {
-                                                    "boxSizing": "border-box",
-                                                    "color": "hsl(0, 0%, 20%)",
-                                                    "margin": 2,
-                                                    "paddingBottom": 2,
-                                                    "paddingTop": 2,
-                                                    "visibility": "visible",
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className="css-b8ldur-Input"
-                                                >
-                                                  <AutosizeInput
-                                                    aria-autocomplete="list"
-                                                    autoCapitalize="none"
-                                                    autoComplete="off"
-                                                    autoCorrect="off"
-                                                    className=""
-                                                    disabled={false}
-                                                    id="react-select-2-input"
-                                                    injectStyles={true}
-                                                    inputRef={[Function]}
-                                                    inputStyle={
+                                                    "controlShouldRenderValue": true,
+                                                    "dropdownIcon": undefined,
+                                                    "escapeClearsValue": false,
+                                                    "filterOption": [Function],
+                                                    "formatGroupLabel": [Function],
+                                                    "getOptionLabel": [Function],
+                                                    "getOptionValue": [Function],
+                                                    "hideDropdownIcon": false,
+                                                    "inputIcon": undefined,
+                                                    "inputValue": "",
+                                                    "isDisabled": false,
+                                                    "isLoading": false,
+                                                    "isMulti": false,
+                                                    "isOptionDisabled": [Function],
+                                                    "isRtl": false,
+                                                    "isSearchable": true,
+                                                    "loadingMessage": [Function],
+                                                    "maxMenuHeight": 300,
+                                                    "menuIsOpen": false,
+                                                    "menuPlacement": "auto",
+                                                    "menuPosition": "absolute",
+                                                    "menuShouldBlockScroll": false,
+                                                    "menuShouldScrollIntoView": true,
+                                                    "minMenuHeight": 140,
+                                                    "noOptionsMessage": [Function],
+                                                    "onChange": [Function],
+                                                    "onInputChange": [Function],
+                                                    "onMenuClose": [Function],
+                                                    "onMenuOpen": [Function],
+                                                    "openMenuOnClick": true,
+                                                    "openMenuOnFocus": false,
+                                                    "options": Array [
                                                       Object {
-                                                        "background": 0,
-                                                        "border": 0,
-                                                        "color": "inherit",
-                                                        "fontSize": "inherit",
-                                                        "label": "input",
-                                                        "opacity": 1,
-                                                        "outline": 0,
-                                                        "padding": 0,
-                                                      }
+                                                        "label": "5",
+                                                        "value": 5,
+                                                      },
+                                                      Object {
+                                                        "label": "20",
+                                                        "value": 20,
+                                                      },
+                                                      Object {
+                                                        "label": "50",
+                                                        "value": 50,
+                                                      },
+                                                    ],
+                                                    "pageSize": 5,
+                                                    "placeholder": "Select...",
+                                                    "screenReaderStatus": [Function],
+                                                    "styles": Object {
+                                                      "clearIndicator": [Function],
+                                                      "container": [Function],
+                                                      "control": [Function],
+                                                      "dropdownIndicator": [Function],
+                                                      "indicatorSeparator": [Function],
+                                                      "indicatorsContainer": [Function],
+                                                      "menu": [Function],
+                                                      "menuList": [Function],
+                                                      "menuPortal": [Function],
+                                                      "option": [Function],
+                                                      "singleValue": [Function],
+                                                      "valueContainer": [Function],
+                                                    },
+                                                    "tabIndex": "0",
+                                                    "tabSelectsValue": true,
+                                                    "value": Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                  }
+                                                }
+                                                setValue={[Function]}
+                                                theme={
+                                                  Object {
+                                                    "borderRadius": 4,
+                                                    "colors": Object {
+                                                      "danger": "#DE350B",
+                                                      "dangerLight": "#FFBDAD",
+                                                      "neutral0": "hsl(0, 0%, 100%)",
+                                                      "neutral10": "hsl(0, 0%, 90%)",
+                                                      "neutral20": "hsl(0, 0%, 80%)",
+                                                      "neutral30": "hsl(0, 0%, 70%)",
+                                                      "neutral40": "hsl(0, 0%, 60%)",
+                                                      "neutral5": "hsl(0, 0%, 95%)",
+                                                      "neutral50": "hsl(0, 0%, 50%)",
+                                                      "neutral60": "hsl(0, 0%, 40%)",
+                                                      "neutral70": "hsl(0, 0%, 30%)",
+                                                      "neutral80": "hsl(0, 0%, 20%)",
+                                                      "neutral90": "hsl(0, 0%, 10%)",
+                                                      "primary": "#2684FF",
+                                                      "primary25": "#DEEBFF",
+                                                      "primary50": "#B2D4FF",
+                                                      "primary75": "#4C9AFF",
+                                                    },
+                                                    "spacing": Object {
+                                                      "baseUnit": 4,
+                                                      "controlHeight": 38,
+                                                      "menuGutter": 8,
+                                                    },
+                                                  }
+                                                }
+                                              >
+                                                <EmotionCssPropInternal
+                                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SingleValue"
+                                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                  className=""
+                                                  css={
+                                                    Object {
+                                                      "boxSizing": "border-box",
+                                                      "color": "inherit",
+                                                      "label": "singleValue",
+                                                      "marginLeft": 2,
+                                                      "marginRight": 2,
+                                                      "maxWidth": "calc(100% - 8px)",
+                                                      "overflow": "hidden",
+                                                      "position": "absolute",
+                                                      "textOverflow": "ellipsis",
+                                                      "top": "50%",
+                                                      "transform": "translateY(-50%)",
+                                                      "whiteSpace": "nowrap",
                                                     }
-                                                    minWidth={1}
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    onFocus={[Function]}
-                                                    spellCheck="false"
-                                                    tabIndex="0"
-                                                    type="text"
-                                                    value=""
+                                                  }
+                                                >
+                                                  <div
+                                                    className=" css-1xqm9c7-singleValue"
                                                   >
-                                                    <div
+                                                    5
+                                                  </div>
+                                                </EmotionCssPropInternal>
+                                              </SingleValue>
+                                              <Input
+                                                aria-autocomplete="list"
+                                                autoCapitalize="none"
+                                                autoComplete="off"
+                                                autoCorrect="off"
+                                                cx={[Function]}
+                                                getStyles={[Function]}
+                                                id="react-select-2-input"
+                                                innerRef={[Function]}
+                                                isDisabled={false}
+                                                isHidden={false}
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                selectProps={
+                                                  Object {
+                                                    "backspaceRemovesValue": true,
+                                                    "blurInputOnSelect": true,
+                                                    "borderless": true,
+                                                    "captureMenuScroll": false,
+                                                    "closeMenuOnScroll": false,
+                                                    "closeMenuOnSelect": true,
+                                                    "components": Object {
+                                                      "DropdownIndicator": [Function],
+                                                      "Option": [Function],
+                                                      "ValueContainer": [Function],
+                                                    },
+                                                    "controlShouldRenderValue": true,
+                                                    "dropdownIcon": undefined,
+                                                    "escapeClearsValue": false,
+                                                    "filterOption": [Function],
+                                                    "formatGroupLabel": [Function],
+                                                    "getOptionLabel": [Function],
+                                                    "getOptionValue": [Function],
+                                                    "hideDropdownIcon": false,
+                                                    "inputIcon": undefined,
+                                                    "inputValue": "",
+                                                    "isDisabled": false,
+                                                    "isLoading": false,
+                                                    "isMulti": false,
+                                                    "isOptionDisabled": [Function],
+                                                    "isRtl": false,
+                                                    "isSearchable": true,
+                                                    "loadingMessage": [Function],
+                                                    "maxMenuHeight": 300,
+                                                    "menuIsOpen": false,
+                                                    "menuPlacement": "auto",
+                                                    "menuPosition": "absolute",
+                                                    "menuShouldBlockScroll": false,
+                                                    "menuShouldScrollIntoView": true,
+                                                    "minMenuHeight": 140,
+                                                    "noOptionsMessage": [Function],
+                                                    "onChange": [Function],
+                                                    "onInputChange": [Function],
+                                                    "onMenuClose": [Function],
+                                                    "onMenuOpen": [Function],
+                                                    "openMenuOnClick": true,
+                                                    "openMenuOnFocus": false,
+                                                    "options": Array [
+                                                      Object {
+                                                        "label": "5",
+                                                        "value": 5,
+                                                      },
+                                                      Object {
+                                                        "label": "20",
+                                                        "value": 20,
+                                                      },
+                                                      Object {
+                                                        "label": "50",
+                                                        "value": 50,
+                                                      },
+                                                    ],
+                                                    "pageSize": 5,
+                                                    "placeholder": "Select...",
+                                                    "screenReaderStatus": [Function],
+                                                    "styles": Object {
+                                                      "clearIndicator": [Function],
+                                                      "container": [Function],
+                                                      "control": [Function],
+                                                      "dropdownIndicator": [Function],
+                                                      "indicatorSeparator": [Function],
+                                                      "indicatorsContainer": [Function],
+                                                      "menu": [Function],
+                                                      "menuList": [Function],
+                                                      "menuPortal": [Function],
+                                                      "option": [Function],
+                                                      "singleValue": [Function],
+                                                      "valueContainer": [Function],
+                                                    },
+                                                    "tabIndex": "0",
+                                                    "tabSelectsValue": true,
+                                                    "value": Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                  }
+                                                }
+                                                spellCheck="false"
+                                                tabIndex="0"
+                                                theme={
+                                                  Object {
+                                                    "borderRadius": 4,
+                                                    "colors": Object {
+                                                      "danger": "#DE350B",
+                                                      "dangerLight": "#FFBDAD",
+                                                      "neutral0": "hsl(0, 0%, 100%)",
+                                                      "neutral10": "hsl(0, 0%, 90%)",
+                                                      "neutral20": "hsl(0, 0%, 80%)",
+                                                      "neutral30": "hsl(0, 0%, 70%)",
+                                                      "neutral40": "hsl(0, 0%, 60%)",
+                                                      "neutral5": "hsl(0, 0%, 95%)",
+                                                      "neutral50": "hsl(0, 0%, 50%)",
+                                                      "neutral60": "hsl(0, 0%, 40%)",
+                                                      "neutral70": "hsl(0, 0%, 30%)",
+                                                      "neutral80": "hsl(0, 0%, 20%)",
+                                                      "neutral90": "hsl(0, 0%, 10%)",
+                                                      "primary": "#2684FF",
+                                                      "primary25": "#DEEBFF",
+                                                      "primary50": "#B2D4FF",
+                                                      "primary75": "#4C9AFF",
+                                                    },
+                                                    "spacing": Object {
+                                                      "baseUnit": 4,
+                                                      "controlHeight": 38,
+                                                      "menuGutter": 8,
+                                                    },
+                                                  }
+                                                }
+                                                type="text"
+                                                value=""
+                                              >
+                                                <EmotionCssPropInternal
+                                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
+                                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                  css={
+                                                    Object {
+                                                      "boxSizing": "border-box",
+                                                      "color": "hsl(0, 0%, 20%)",
+                                                      "margin": 2,
+                                                      "paddingBottom": 2,
+                                                      "paddingTop": 2,
+                                                      "visibility": "visible",
+                                                    }
+                                                  }
+                                                >
+                                                  <div
+                                                    className="css-b8ldur-Input"
+                                                  >
+                                                    <AutosizeInput
+                                                      aria-autocomplete="list"
+                                                      autoCapitalize="none"
+                                                      autoComplete="off"
+                                                      autoCorrect="off"
                                                       className=""
-                                                      style={
+                                                      disabled={false}
+                                                      id="react-select-2-input"
+                                                      injectStyles={true}
+                                                      inputRef={[Function]}
+                                                      inputStyle={
                                                         Object {
-                                                          "display": "inline-block",
+                                                          "background": 0,
+                                                          "border": 0,
+                                                          "color": "inherit",
+                                                          "fontSize": "inherit",
+                                                          "label": "input",
+                                                          "opacity": 1,
+                                                          "outline": 0,
+                                                          "padding": 0,
                                                         }
                                                       }
+                                                      minWidth={1}
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      onFocus={[Function]}
+                                                      spellCheck="false"
+                                                      tabIndex="0"
+                                                      type="text"
+                                                      value=""
                                                     >
-                                                      <input
-                                                        aria-autocomplete="list"
-                                                        autoCapitalize="none"
-                                                        autoComplete="off"
-                                                        autoCorrect="off"
-                                                        disabled={false}
-                                                        id="react-select-2-input"
-                                                        onBlur={[Function]}
-                                                        onChange={[Function]}
-                                                        onFocus={[Function]}
-                                                        spellCheck="false"
-                                                        style={
-                                                          Object {
-                                                            "background": 0,
-                                                            "border": 0,
-                                                            "boxSizing": "content-box",
-                                                            "color": "inherit",
-                                                            "fontSize": "inherit",
-                                                            "label": "input",
-                                                            "opacity": 1,
-                                                            "outline": 0,
-                                                            "padding": 0,
-                                                            "width": "2px",
-                                                          }
-                                                        }
-                                                        tabIndex="0"
-                                                        type="text"
-                                                        value=""
-                                                      />
                                                       <div
+                                                        className=""
                                                         style={
                                                           Object {
-                                                            "height": 0,
-                                                            "left": 0,
-                                                            "overflow": "scroll",
-                                                            "position": "absolute",
-                                                            "top": 0,
-                                                            "visibility": "hidden",
-                                                            "whiteSpace": "pre",
+                                                            "display": "inline-block",
                                                           }
                                                         }
-                                                      />
-                                                    </div>
-                                                  </AutosizeInput>
-                                                </div>
-                                              </EmotionCssPropInternal>
-                                            </Input>
-                                          </div>
-                                        </EmotionCssPropInternal>
+                                                      >
+                                                        <input
+                                                          aria-autocomplete="list"
+                                                          autoCapitalize="none"
+                                                          autoComplete="off"
+                                                          autoCorrect="off"
+                                                          disabled={false}
+                                                          id="react-select-2-input"
+                                                          onBlur={[Function]}
+                                                          onChange={[Function]}
+                                                          onFocus={[Function]}
+                                                          spellCheck="false"
+                                                          style={
+                                                            Object {
+                                                              "background": 0,
+                                                              "border": 0,
+                                                              "boxSizing": "content-box",
+                                                              "color": "inherit",
+                                                              "fontSize": "inherit",
+                                                              "label": "input",
+                                                              "opacity": 1,
+                                                              "outline": 0,
+                                                              "padding": 0,
+                                                              "width": "2px",
+                                                            }
+                                                          }
+                                                          tabIndex="0"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                        <div
+                                                          style={
+                                                            Object {
+                                                              "height": 0,
+                                                              "left": 0,
+                                                              "overflow": "scroll",
+                                                              "position": "absolute",
+                                                              "top": 0,
+                                                              "visibility": "hidden",
+                                                              "whiteSpace": "pre",
+                                                            }
+                                                          }
+                                                        />
+                                                      </div>
+                                                    </AutosizeInput>
+                                                  </div>
+                                                </EmotionCssPropInternal>
+                                              </Input>
+                                            </div>
+                                          </EmotionCssPropInternal>
+                                        </ValueContainer>
                                       </ValueContainer>
                                       <IndicatorsContainer
                                         clearValue={[Function]}
@@ -6002,15 +6172,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                             "closeMenuOnScroll": false,
                                             "closeMenuOnSelect": true,
                                             "components": Object {
+                                              "DropdownIndicator": [Function],
                                               "Option": [Function],
+                                              "ValueContainer": [Function],
                                             },
                                             "controlShouldRenderValue": true,
+                                            "dropdownIcon": undefined,
                                             "escapeClearsValue": false,
                                             "filterOption": [Function],
                                             "formatGroupLabel": [Function],
                                             "getOptionLabel": [Function],
                                             "getOptionValue": [Function],
-                                            "icon": undefined,
+                                            "hideDropdownIcon": false,
+                                            "inputIcon": undefined,
                                             "inputValue": "",
                                             "isDisabled": false,
                                             "isLoading": false,
@@ -6158,15 +6332,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                   "closeMenuOnScroll": false,
                                                   "closeMenuOnSelect": true,
                                                   "components": Object {
+                                                    "DropdownIndicator": [Function],
                                                     "Option": [Function],
+                                                    "ValueContainer": [Function],
                                                   },
                                                   "controlShouldRenderValue": true,
+                                                  "dropdownIcon": undefined,
                                                   "escapeClearsValue": false,
                                                   "filterOption": [Function],
                                                   "formatGroupLabel": [Function],
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
-                                                  "icon": undefined,
+                                                  "hideDropdownIcon": false,
+                                                  "inputIcon": undefined,
                                                   "inputValue": "",
                                                   "isDisabled": false,
                                                   "isLoading": false,
@@ -6274,7 +6452,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                 />
                                               </EmotionCssPropInternal>
                                             </IndicatorSeparator>
-                                            <DropdownIndicator
+                                            <LUKDropdownIndicator
                                               clearValue={[Function]}
                                               cx={[Function]}
                                               getStyles={[Function]}
@@ -6317,15 +6495,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                   "closeMenuOnScroll": false,
                                                   "closeMenuOnSelect": true,
                                                   "components": Object {
+                                                    "DropdownIndicator": [Function],
                                                     "Option": [Function],
+                                                    "ValueContainer": [Function],
                                                   },
                                                   "controlShouldRenderValue": true,
+                                                  "dropdownIcon": undefined,
                                                   "escapeClearsValue": false,
                                                   "filterOption": [Function],
                                                   "formatGroupLabel": [Function],
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
-                                                  "icon": undefined,
+                                                  "hideDropdownIcon": false,
+                                                  "inputIcon": undefined,
                                                   "inputValue": "",
                                                   "isDisabled": false,
                                                   "isLoading": false,
@@ -6418,66 +6600,215 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                 }
                                               }
                                             >
-                                              <EmotionCssPropInternal
-                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
-                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                                aria-hidden="true"
-                                                className=""
-                                                css={
+                                              <DropdownIndicator
+                                                clearValue={[Function]}
+                                                cx={[Function]}
+                                                getStyles={[Function]}
+                                                getValue={[Function]}
+                                                hasValue={true}
+                                                innerProps={
                                                   Object {
-                                                    "color": "#b6bbc7",
-                                                    "display": "flex",
-                                                    "margin": "5px",
-                                                    "padding": "0",
+                                                    "aria-hidden": "true",
+                                                    "onMouseDown": [Function],
+                                                    "onTouchEnd": [Function],
                                                   }
                                                 }
-                                                onMouseDown={[Function]}
-                                                onTouchEnd={[Function]}
+                                                isDisabled={false}
+                                                isFocused={false}
+                                                isMulti={false}
+                                                isRtl={false}
+                                                options={
+                                                  Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ]
+                                                }
+                                                selectOption={[Function]}
+                                                selectProps={
+                                                  Object {
+                                                    "backspaceRemovesValue": true,
+                                                    "blurInputOnSelect": true,
+                                                    "borderless": true,
+                                                    "captureMenuScroll": false,
+                                                    "closeMenuOnScroll": false,
+                                                    "closeMenuOnSelect": true,
+                                                    "components": Object {
+                                                      "DropdownIndicator": [Function],
+                                                      "Option": [Function],
+                                                      "ValueContainer": [Function],
+                                                    },
+                                                    "controlShouldRenderValue": true,
+                                                    "dropdownIcon": undefined,
+                                                    "escapeClearsValue": false,
+                                                    "filterOption": [Function],
+                                                    "formatGroupLabel": [Function],
+                                                    "getOptionLabel": [Function],
+                                                    "getOptionValue": [Function],
+                                                    "hideDropdownIcon": false,
+                                                    "inputIcon": undefined,
+                                                    "inputValue": "",
+                                                    "isDisabled": false,
+                                                    "isLoading": false,
+                                                    "isMulti": false,
+                                                    "isOptionDisabled": [Function],
+                                                    "isRtl": false,
+                                                    "isSearchable": true,
+                                                    "loadingMessage": [Function],
+                                                    "maxMenuHeight": 300,
+                                                    "menuIsOpen": false,
+                                                    "menuPlacement": "auto",
+                                                    "menuPosition": "absolute",
+                                                    "menuShouldBlockScroll": false,
+                                                    "menuShouldScrollIntoView": true,
+                                                    "minMenuHeight": 140,
+                                                    "noOptionsMessage": [Function],
+                                                    "onChange": [Function],
+                                                    "onInputChange": [Function],
+                                                    "onMenuClose": [Function],
+                                                    "onMenuOpen": [Function],
+                                                    "openMenuOnClick": true,
+                                                    "openMenuOnFocus": false,
+                                                    "options": Array [
+                                                      Object {
+                                                        "label": "5",
+                                                        "value": 5,
+                                                      },
+                                                      Object {
+                                                        "label": "20",
+                                                        "value": 20,
+                                                      },
+                                                      Object {
+                                                        "label": "50",
+                                                        "value": 50,
+                                                      },
+                                                    ],
+                                                    "pageSize": 5,
+                                                    "placeholder": "Select...",
+                                                    "screenReaderStatus": [Function],
+                                                    "styles": Object {
+                                                      "clearIndicator": [Function],
+                                                      "container": [Function],
+                                                      "control": [Function],
+                                                      "dropdownIndicator": [Function],
+                                                      "indicatorSeparator": [Function],
+                                                      "indicatorsContainer": [Function],
+                                                      "menu": [Function],
+                                                      "menuList": [Function],
+                                                      "menuPortal": [Function],
+                                                      "option": [Function],
+                                                      "singleValue": [Function],
+                                                      "valueContainer": [Function],
+                                                    },
+                                                    "tabIndex": "0",
+                                                    "tabSelectsValue": true,
+                                                    "value": Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                  }
+                                                }
+                                                setValue={[Function]}
+                                                theme={
+                                                  Object {
+                                                    "borderRadius": 4,
+                                                    "colors": Object {
+                                                      "danger": "#DE350B",
+                                                      "dangerLight": "#FFBDAD",
+                                                      "neutral0": "hsl(0, 0%, 100%)",
+                                                      "neutral10": "hsl(0, 0%, 90%)",
+                                                      "neutral20": "hsl(0, 0%, 80%)",
+                                                      "neutral30": "hsl(0, 0%, 70%)",
+                                                      "neutral40": "hsl(0, 0%, 60%)",
+                                                      "neutral5": "hsl(0, 0%, 95%)",
+                                                      "neutral50": "hsl(0, 0%, 50%)",
+                                                      "neutral60": "hsl(0, 0%, 40%)",
+                                                      "neutral70": "hsl(0, 0%, 30%)",
+                                                      "neutral80": "hsl(0, 0%, 20%)",
+                                                      "neutral90": "hsl(0, 0%, 10%)",
+                                                      "primary": "#2684FF",
+                                                      "primary25": "#DEEBFF",
+                                                      "primary50": "#B2D4FF",
+                                                      "primary75": "#4C9AFF",
+                                                    },
+                                                    "spacing": Object {
+                                                      "baseUnit": 4,
+                                                      "controlHeight": 38,
+                                                      "menuGutter": 8,
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
+                                                <EmotionCssPropInternal
+                                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
+                                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
                                                   aria-hidden="true"
-                                                  className=" css-1vd5qh6-DropdownIndicator"
+                                                  className=""
+                                                  css={
+                                                    Object {
+                                                      "color": "#b6bbc7",
+                                                      "display": "flex",
+                                                      "margin": "5px",
+                                                      "padding": "0",
+                                                    }
+                                                  }
                                                   onMouseDown={[Function]}
                                                   onTouchEnd={[Function]}
                                                 >
-                                                  <DownChevron>
-                                                    <Svg
-                                                      size={20}
-                                                    >
-                                                      <EmotionCssPropInternal
-                                                        __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
-                                                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
-                                                        aria-hidden="true"
-                                                        css={
-                                                          Object {
-                                                            "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
-                                                            "name": "19bqh2r",
-                                                            "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
-                                                          }
-                                                        }
-                                                        focusable="false"
-                                                        height={20}
-                                                        viewBox="0 0 20 20"
-                                                        width={20}
+                                                  <div
+                                                    aria-hidden="true"
+                                                    className=" css-1vd5qh6-DropdownIndicator"
+                                                    onMouseDown={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                  >
+                                                    <DownChevron>
+                                                      <Svg
+                                                        size={20}
                                                       >
-                                                        <svg
+                                                        <EmotionCssPropInternal
+                                                          __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
+                                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
                                                           aria-hidden="true"
-                                                          className="css-6q0nyr-Svg"
+                                                          css={
+                                                            Object {
+                                                              "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
+                                                              "name": "19bqh2r",
+                                                              "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
+                                                            }
+                                                          }
                                                           focusable="false"
                                                           height={20}
                                                           viewBox="0 0 20 20"
                                                           width={20}
                                                         >
-                                                          <path
-                                                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                                                          />
-                                                        </svg>
-                                                      </EmotionCssPropInternal>
-                                                    </Svg>
-                                                  </DownChevron>
-                                                </div>
-                                              </EmotionCssPropInternal>
-                                            </DropdownIndicator>
+                                                          <svg
+                                                            aria-hidden="true"
+                                                            className="css-6q0nyr-Svg"
+                                                            focusable="false"
+                                                            height={20}
+                                                            viewBox="0 0 20 20"
+                                                            width={20}
+                                                          >
+                                                            <path
+                                                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                                            />
+                                                          </svg>
+                                                        </EmotionCssPropInternal>
+                                                      </Svg>
+                                                    </DownChevron>
+                                                  </div>
+                                                </EmotionCssPropInternal>
+                                              </DropdownIndicator>
+                                            </LUKDropdownIndicator>
                                           </div>
                                         </EmotionCssPropInternal>
                                       </IndicatorsContainer>
@@ -9595,6 +9926,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           "value": 5,
                         }
                       }
+                      hideDropdownIcon={false}
                       onChange={[Function]}
                       options={
                         Array [
@@ -9620,7 +9952,9 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                         borderless={true}
                         components={
                           Object {
+                            "DropdownIndicator": [Function],
                             "Option": [Function],
+                            "ValueContainer": [Function],
                           }
                         }
                         defaultInputValue=""
@@ -9632,6 +9966,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           }
                         }
                         filterOption={[Function]}
+                        hideDropdownIcon={false}
                         menuPlacement="auto"
                         onChange={[Function]}
                         options={
@@ -9682,7 +10017,9 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           closeMenuOnSelect={true}
                           components={
                             Object {
+                              "DropdownIndicator": [Function],
                               "Option": [Function],
+                              "ValueContainer": [Function],
                             }
                           }
                           controlShouldRenderValue={true}
@@ -9691,6 +10028,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                           formatGroupLabel={[Function]}
                           getOptionLabel={[Function]}
                           getOptionValue={[Function]}
+                          hideDropdownIcon={false}
                           inputValue=""
                           isDisabled={false}
                           isLoading={false}
@@ -9799,15 +10137,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                 "closeMenuOnScroll": false,
                                 "closeMenuOnSelect": true,
                                 "components": Object {
+                                  "DropdownIndicator": [Function],
                                   "Option": [Function],
+                                  "ValueContainer": [Function],
                                 },
                                 "controlShouldRenderValue": true,
+                                "dropdownIcon": undefined,
                                 "escapeClearsValue": false,
                                 "filterOption": [Function],
                                 "formatGroupLabel": [Function],
                                 "getOptionLabel": [Function],
                                 "getOptionValue": [Function],
-                                "icon": undefined,
+                                "hideDropdownIcon": false,
+                                "inputIcon": undefined,
                                 "inputValue": "",
                                 "isDisabled": false,
                                 "isLoading": false,
@@ -9965,15 +10307,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                       "closeMenuOnScroll": false,
                                       "closeMenuOnSelect": true,
                                       "components": Object {
+                                        "DropdownIndicator": [Function],
                                         "Option": [Function],
+                                        "ValueContainer": [Function],
                                       },
                                       "controlShouldRenderValue": true,
+                                      "dropdownIcon": undefined,
                                       "escapeClearsValue": false,
                                       "filterOption": [Function],
                                       "formatGroupLabel": [Function],
                                       "getOptionLabel": [Function],
                                       "getOptionValue": [Function],
-                                      "icon": undefined,
+                                      "hideDropdownIcon": false,
+                                      "inputIcon": undefined,
                                       "inputValue": "",
                                       "isDisabled": false,
                                       "isLoading": false,
@@ -10116,6 +10462,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                         getStyles={[Function]}
                                         getValue={[Function]}
                                         hasValue={true}
+                                        inputIcon={null}
                                         isDisabled={false}
                                         isMulti={false}
                                         isRtl={false}
@@ -10145,15 +10492,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                             "closeMenuOnScroll": false,
                                             "closeMenuOnSelect": true,
                                             "components": Object {
+                                              "DropdownIndicator": [Function],
                                               "Option": [Function],
+                                              "ValueContainer": [Function],
                                             },
                                             "controlShouldRenderValue": true,
+                                            "dropdownIcon": undefined,
                                             "escapeClearsValue": false,
                                             "filterOption": [Function],
                                             "formatGroupLabel": [Function],
                                             "getOptionLabel": [Function],
                                             "getOptionValue": [Function],
-                                            "icon": undefined,
+                                            "hideDropdownIcon": false,
+                                            "inputIcon": undefined,
                                             "inputValue": "",
                                             "isDisabled": false,
                                             "isLoading": false,
@@ -10246,99 +10597,184 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                           }
                                         }
                                       >
-                                        <EmotionCssPropInternal
-                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                          className=""
-                                          css={
-                                            Object {
-                                              "WebkitOverflowScrolling": "touch",
-                                              "alignItems": "center",
-                                              "boxSizing": "border-box",
-                                              "display": "flex",
-                                              "flex": 1,
-                                              "flexWrap": "wrap",
-                                              "overflow": "hidden",
-                                              "padding": "0 10px",
-                                              "position": "relative",
-                                            }
+                                        <ValueContainer
+                                          clearValue={[Function]}
+                                          cx={[Function]}
+                                          getStyles={[Function]}
+                                          getValue={[Function]}
+                                          hasValue={true}
+                                          inputIcon={null}
+                                          isDisabled={false}
+                                          isMulti={false}
+                                          isRtl={false}
+                                          options={
+                                            Array [
+                                              Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                              Object {
+                                                "label": "20",
+                                                "value": 20,
+                                              },
+                                              Object {
+                                                "label": "50",
+                                                "value": 50,
+                                              },
+                                            ]
                                           }
-                                        >
-                                          <div
-                                            className=" css-1gbz4ua"
-                                          >
-                                            <SingleValue
-                                              clearValue={[Function]}
-                                              cx={[Function]}
-                                              data={
+                                          selectOption={[Function]}
+                                          selectProps={
+                                            Object {
+                                              "backspaceRemovesValue": true,
+                                              "blurInputOnSelect": true,
+                                              "borderless": true,
+                                              "captureMenuScroll": false,
+                                              "closeMenuOnScroll": false,
+                                              "closeMenuOnSelect": true,
+                                              "components": Object {
+                                                "DropdownIndicator": [Function],
+                                                "Option": [Function],
+                                                "ValueContainer": [Function],
+                                              },
+                                              "controlShouldRenderValue": true,
+                                              "dropdownIcon": undefined,
+                                              "escapeClearsValue": false,
+                                              "filterOption": [Function],
+                                              "formatGroupLabel": [Function],
+                                              "getOptionLabel": [Function],
+                                              "getOptionValue": [Function],
+                                              "hideDropdownIcon": false,
+                                              "inputIcon": undefined,
+                                              "inputValue": "",
+                                              "isDisabled": false,
+                                              "isLoading": false,
+                                              "isMulti": false,
+                                              "isOptionDisabled": [Function],
+                                              "isRtl": false,
+                                              "isSearchable": true,
+                                              "loadingMessage": [Function],
+                                              "maxMenuHeight": 300,
+                                              "menuIsOpen": false,
+                                              "menuPlacement": "auto",
+                                              "menuPosition": "absolute",
+                                              "menuShouldBlockScroll": false,
+                                              "menuShouldScrollIntoView": true,
+                                              "minMenuHeight": 140,
+                                              "noOptionsMessage": [Function],
+                                              "onChange": [Function],
+                                              "onInputChange": [Function],
+                                              "onMenuClose": [Function],
+                                              "onMenuOpen": [Function],
+                                              "openMenuOnClick": true,
+                                              "openMenuOnFocus": false,
+                                              "options": Array [
                                                 Object {
                                                   "label": "5",
                                                   "value": 5,
-                                                }
+                                                },
+                                                Object {
+                                                  "label": "20",
+                                                  "value": 20,
+                                                },
+                                                Object {
+                                                  "label": "50",
+                                                  "value": 50,
+                                                },
+                                              ],
+                                              "pageSize": 5,
+                                              "placeholder": "Select...",
+                                              "screenReaderStatus": [Function],
+                                              "styles": Object {
+                                                "clearIndicator": [Function],
+                                                "container": [Function],
+                                                "control": [Function],
+                                                "dropdownIndicator": [Function],
+                                                "indicatorSeparator": [Function],
+                                                "indicatorsContainer": [Function],
+                                                "menu": [Function],
+                                                "menuList": [Function],
+                                                "menuPortal": [Function],
+                                                "option": [Function],
+                                                "singleValue": [Function],
+                                                "valueContainer": [Function],
+                                              },
+                                              "tabIndex": "0",
+                                              "tabSelectsValue": true,
+                                              "value": Object {
+                                                "label": "5",
+                                                "value": 5,
+                                              },
+                                            }
+                                          }
+                                          setValue={[Function]}
+                                          theme={
+                                            Object {
+                                              "borderRadius": 4,
+                                              "colors": Object {
+                                                "danger": "#DE350B",
+                                                "dangerLight": "#FFBDAD",
+                                                "neutral0": "hsl(0, 0%, 100%)",
+                                                "neutral10": "hsl(0, 0%, 90%)",
+                                                "neutral20": "hsl(0, 0%, 80%)",
+                                                "neutral30": "hsl(0, 0%, 70%)",
+                                                "neutral40": "hsl(0, 0%, 60%)",
+                                                "neutral5": "hsl(0, 0%, 95%)",
+                                                "neutral50": "hsl(0, 0%, 50%)",
+                                                "neutral60": "hsl(0, 0%, 40%)",
+                                                "neutral70": "hsl(0, 0%, 30%)",
+                                                "neutral80": "hsl(0, 0%, 20%)",
+                                                "neutral90": "hsl(0, 0%, 10%)",
+                                                "primary": "#2684FF",
+                                                "primary25": "#DEEBFF",
+                                                "primary50": "#B2D4FF",
+                                                "primary75": "#4C9AFF",
+                                              },
+                                              "spacing": Object {
+                                                "baseUnit": 4,
+                                                "controlHeight": 38,
+                                                "menuGutter": 8,
+                                              },
+                                            }
+                                          }
+                                        >
+                                          <EmotionCssPropInternal
+                                            __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                            className=""
+                                            css={
+                                              Object {
+                                                "WebkitOverflowScrolling": "touch",
+                                                "alignItems": "center",
+                                                "boxSizing": "border-box",
+                                                "display": "flex",
+                                                "flex": 1,
+                                                "flexWrap": "wrap",
+                                                "overflow": "hidden",
+                                                "padding": "0 10px",
+                                                "position": "relative",
                                               }
-                                              getStyles={[Function]}
-                                              getValue={[Function]}
-                                              hasValue={true}
-                                              isDisabled={false}
-                                              isMulti={false}
-                                              isRtl={false}
-                                              options={
-                                                Array [
+                                            }
+                                          >
+                                            <div
+                                              className=" css-1gbz4ua"
+                                            >
+                                              <SingleValue
+                                                clearValue={[Function]}
+                                                cx={[Function]}
+                                                data={
                                                   Object {
                                                     "label": "5",
                                                     "value": 5,
-                                                  },
-                                                  Object {
-                                                    "label": "20",
-                                                    "value": 20,
-                                                  },
-                                                  Object {
-                                                    "label": "50",
-                                                    "value": 50,
-                                                  },
-                                                ]
-                                              }
-                                              selectOption={[Function]}
-                                              selectProps={
-                                                Object {
-                                                  "backspaceRemovesValue": true,
-                                                  "blurInputOnSelect": true,
-                                                  "borderless": true,
-                                                  "captureMenuScroll": false,
-                                                  "closeMenuOnScroll": false,
-                                                  "closeMenuOnSelect": true,
-                                                  "components": Object {
-                                                    "Option": [Function],
-                                                  },
-                                                  "controlShouldRenderValue": true,
-                                                  "escapeClearsValue": false,
-                                                  "filterOption": [Function],
-                                                  "formatGroupLabel": [Function],
-                                                  "getOptionLabel": [Function],
-                                                  "getOptionValue": [Function],
-                                                  "icon": undefined,
-                                                  "inputValue": "",
-                                                  "isDisabled": false,
-                                                  "isLoading": false,
-                                                  "isMulti": false,
-                                                  "isOptionDisabled": [Function],
-                                                  "isRtl": false,
-                                                  "isSearchable": true,
-                                                  "loadingMessage": [Function],
-                                                  "maxMenuHeight": 300,
-                                                  "menuIsOpen": false,
-                                                  "menuPlacement": "auto",
-                                                  "menuPosition": "absolute",
-                                                  "menuShouldBlockScroll": false,
-                                                  "menuShouldScrollIntoView": true,
-                                                  "minMenuHeight": 140,
-                                                  "noOptionsMessage": [Function],
-                                                  "onChange": [Function],
-                                                  "onInputChange": [Function],
-                                                  "onMenuClose": [Function],
-                                                  "onMenuOpen": [Function],
-                                                  "openMenuOnClick": true,
-                                                  "openMenuOnFocus": false,
-                                                  "options": Array [
+                                                  }
+                                                }
+                                                getStyles={[Function]}
+                                                getValue={[Function]}
+                                                hasValue={true}
+                                                isDisabled={false}
+                                                isMulti={false}
+                                                isRtl={false}
+                                                options={
+                                                  Array [
                                                     Object {
                                                       "label": "5",
                                                       "value": 5,
@@ -10351,323 +10787,388 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                       "label": "50",
                                                       "value": 50,
                                                     },
-                                                  ],
-                                                  "pageSize": 5,
-                                                  "placeholder": "Select...",
-                                                  "screenReaderStatus": [Function],
-                                                  "styles": Object {
-                                                    "clearIndicator": [Function],
-                                                    "container": [Function],
-                                                    "control": [Function],
-                                                    "dropdownIndicator": [Function],
-                                                    "indicatorSeparator": [Function],
-                                                    "indicatorsContainer": [Function],
-                                                    "menu": [Function],
-                                                    "menuList": [Function],
-                                                    "menuPortal": [Function],
-                                                    "option": [Function],
-                                                    "singleValue": [Function],
-                                                    "valueContainer": [Function],
-                                                  },
-                                                  "tabIndex": "0",
-                                                  "tabSelectsValue": true,
-                                                  "value": Object {
-                                                    "label": "5",
-                                                    "value": 5,
-                                                  },
+                                                  ]
                                                 }
-                                              }
-                                              setValue={[Function]}
-                                              theme={
-                                                Object {
-                                                  "borderRadius": 4,
-                                                  "colors": Object {
-                                                    "danger": "#DE350B",
-                                                    "dangerLight": "#FFBDAD",
-                                                    "neutral0": "hsl(0, 0%, 100%)",
-                                                    "neutral10": "hsl(0, 0%, 90%)",
-                                                    "neutral20": "hsl(0, 0%, 80%)",
-                                                    "neutral30": "hsl(0, 0%, 70%)",
-                                                    "neutral40": "hsl(0, 0%, 60%)",
-                                                    "neutral5": "hsl(0, 0%, 95%)",
-                                                    "neutral50": "hsl(0, 0%, 50%)",
-                                                    "neutral60": "hsl(0, 0%, 40%)",
-                                                    "neutral70": "hsl(0, 0%, 30%)",
-                                                    "neutral80": "hsl(0, 0%, 20%)",
-                                                    "neutral90": "hsl(0, 0%, 10%)",
-                                                    "primary": "#2684FF",
-                                                    "primary25": "#DEEBFF",
-                                                    "primary50": "#B2D4FF",
-                                                    "primary75": "#4C9AFF",
-                                                  },
-                                                  "spacing": Object {
-                                                    "baseUnit": 4,
-                                                    "controlHeight": 38,
-                                                    "menuGutter": 8,
-                                                  },
-                                                }
-                                              }
-                                            >
-                                              <EmotionCssPropInternal
-                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SingleValue"
-                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                                className=""
-                                                css={
+                                                selectOption={[Function]}
+                                                selectProps={
                                                   Object {
-                                                    "boxSizing": "border-box",
-                                                    "color": "inherit",
-                                                    "label": "singleValue",
-                                                    "marginLeft": 2,
-                                                    "marginRight": 2,
-                                                    "maxWidth": "calc(100% - 8px)",
-                                                    "overflow": "hidden",
-                                                    "position": "absolute",
-                                                    "textOverflow": "ellipsis",
-                                                    "top": "50%",
-                                                    "transform": "translateY(-50%)",
-                                                    "whiteSpace": "nowrap",
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className=" css-1xqm9c7-singleValue"
-                                                >
-                                                  5
-                                                </div>
-                                              </EmotionCssPropInternal>
-                                            </SingleValue>
-                                            <Input
-                                              aria-autocomplete="list"
-                                              autoCapitalize="none"
-                                              autoComplete="off"
-                                              autoCorrect="off"
-                                              cx={[Function]}
-                                              getStyles={[Function]}
-                                              id="react-select-3-input"
-                                              innerRef={[Function]}
-                                              isDisabled={false}
-                                              isHidden={false}
-                                              onBlur={[Function]}
-                                              onChange={[Function]}
-                                              onFocus={[Function]}
-                                              selectProps={
-                                                Object {
-                                                  "backspaceRemovesValue": true,
-                                                  "blurInputOnSelect": true,
-                                                  "borderless": true,
-                                                  "captureMenuScroll": false,
-                                                  "closeMenuOnScroll": false,
-                                                  "closeMenuOnSelect": true,
-                                                  "components": Object {
-                                                    "Option": [Function],
-                                                  },
-                                                  "controlShouldRenderValue": true,
-                                                  "escapeClearsValue": false,
-                                                  "filterOption": [Function],
-                                                  "formatGroupLabel": [Function],
-                                                  "getOptionLabel": [Function],
-                                                  "getOptionValue": [Function],
-                                                  "icon": undefined,
-                                                  "inputValue": "",
-                                                  "isDisabled": false,
-                                                  "isLoading": false,
-                                                  "isMulti": false,
-                                                  "isOptionDisabled": [Function],
-                                                  "isRtl": false,
-                                                  "isSearchable": true,
-                                                  "loadingMessage": [Function],
-                                                  "maxMenuHeight": 300,
-                                                  "menuIsOpen": false,
-                                                  "menuPlacement": "auto",
-                                                  "menuPosition": "absolute",
-                                                  "menuShouldBlockScroll": false,
-                                                  "menuShouldScrollIntoView": true,
-                                                  "minMenuHeight": 140,
-                                                  "noOptionsMessage": [Function],
-                                                  "onChange": [Function],
-                                                  "onInputChange": [Function],
-                                                  "onMenuClose": [Function],
-                                                  "onMenuOpen": [Function],
-                                                  "openMenuOnClick": true,
-                                                  "openMenuOnFocus": false,
-                                                  "options": Array [
-                                                    Object {
-                                                      "label": "5",
-                                                      "value": 5,
+                                                    "backspaceRemovesValue": true,
+                                                    "blurInputOnSelect": true,
+                                                    "borderless": true,
+                                                    "captureMenuScroll": false,
+                                                    "closeMenuOnScroll": false,
+                                                    "closeMenuOnSelect": true,
+                                                    "components": Object {
+                                                      "DropdownIndicator": [Function],
+                                                      "Option": [Function],
+                                                      "ValueContainer": [Function],
                                                     },
-                                                    Object {
-                                                      "label": "20",
-                                                      "value": 20,
-                                                    },
-                                                    Object {
-                                                      "label": "50",
-                                                      "value": 50,
-                                                    },
-                                                  ],
-                                                  "pageSize": 5,
-                                                  "placeholder": "Select...",
-                                                  "screenReaderStatus": [Function],
-                                                  "styles": Object {
-                                                    "clearIndicator": [Function],
-                                                    "container": [Function],
-                                                    "control": [Function],
-                                                    "dropdownIndicator": [Function],
-                                                    "indicatorSeparator": [Function],
-                                                    "indicatorsContainer": [Function],
-                                                    "menu": [Function],
-                                                    "menuList": [Function],
-                                                    "menuPortal": [Function],
-                                                    "option": [Function],
-                                                    "singleValue": [Function],
-                                                    "valueContainer": [Function],
-                                                  },
-                                                  "tabIndex": "0",
-                                                  "tabSelectsValue": true,
-                                                  "value": Object {
-                                                    "label": "5",
-                                                    "value": 5,
-                                                  },
-                                                }
-                                              }
-                                              spellCheck="false"
-                                              tabIndex="0"
-                                              theme={
-                                                Object {
-                                                  "borderRadius": 4,
-                                                  "colors": Object {
-                                                    "danger": "#DE350B",
-                                                    "dangerLight": "#FFBDAD",
-                                                    "neutral0": "hsl(0, 0%, 100%)",
-                                                    "neutral10": "hsl(0, 0%, 90%)",
-                                                    "neutral20": "hsl(0, 0%, 80%)",
-                                                    "neutral30": "hsl(0, 0%, 70%)",
-                                                    "neutral40": "hsl(0, 0%, 60%)",
-                                                    "neutral5": "hsl(0, 0%, 95%)",
-                                                    "neutral50": "hsl(0, 0%, 50%)",
-                                                    "neutral60": "hsl(0, 0%, 40%)",
-                                                    "neutral70": "hsl(0, 0%, 30%)",
-                                                    "neutral80": "hsl(0, 0%, 20%)",
-                                                    "neutral90": "hsl(0, 0%, 10%)",
-                                                    "primary": "#2684FF",
-                                                    "primary25": "#DEEBFF",
-                                                    "primary50": "#B2D4FF",
-                                                    "primary75": "#4C9AFF",
-                                                  },
-                                                  "spacing": Object {
-                                                    "baseUnit": 4,
-                                                    "controlHeight": 38,
-                                                    "menuGutter": 8,
-                                                  },
-                                                }
-                                              }
-                                              type="text"
-                                              value=""
-                                            >
-                                              <EmotionCssPropInternal
-                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
-                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                                css={
-                                                  Object {
-                                                    "boxSizing": "border-box",
-                                                    "color": "hsl(0, 0%, 20%)",
-                                                    "margin": 2,
-                                                    "paddingBottom": 2,
-                                                    "paddingTop": 2,
-                                                    "visibility": "visible",
-                                                  }
-                                                }
-                                              >
-                                                <div
-                                                  className="css-b8ldur-Input"
-                                                >
-                                                  <AutosizeInput
-                                                    aria-autocomplete="list"
-                                                    autoCapitalize="none"
-                                                    autoComplete="off"
-                                                    autoCorrect="off"
-                                                    className=""
-                                                    disabled={false}
-                                                    id="react-select-3-input"
-                                                    injectStyles={true}
-                                                    inputRef={[Function]}
-                                                    inputStyle={
+                                                    "controlShouldRenderValue": true,
+                                                    "dropdownIcon": undefined,
+                                                    "escapeClearsValue": false,
+                                                    "filterOption": [Function],
+                                                    "formatGroupLabel": [Function],
+                                                    "getOptionLabel": [Function],
+                                                    "getOptionValue": [Function],
+                                                    "hideDropdownIcon": false,
+                                                    "inputIcon": undefined,
+                                                    "inputValue": "",
+                                                    "isDisabled": false,
+                                                    "isLoading": false,
+                                                    "isMulti": false,
+                                                    "isOptionDisabled": [Function],
+                                                    "isRtl": false,
+                                                    "isSearchable": true,
+                                                    "loadingMessage": [Function],
+                                                    "maxMenuHeight": 300,
+                                                    "menuIsOpen": false,
+                                                    "menuPlacement": "auto",
+                                                    "menuPosition": "absolute",
+                                                    "menuShouldBlockScroll": false,
+                                                    "menuShouldScrollIntoView": true,
+                                                    "minMenuHeight": 140,
+                                                    "noOptionsMessage": [Function],
+                                                    "onChange": [Function],
+                                                    "onInputChange": [Function],
+                                                    "onMenuClose": [Function],
+                                                    "onMenuOpen": [Function],
+                                                    "openMenuOnClick": true,
+                                                    "openMenuOnFocus": false,
+                                                    "options": Array [
                                                       Object {
-                                                        "background": 0,
-                                                        "border": 0,
-                                                        "color": "inherit",
-                                                        "fontSize": "inherit",
-                                                        "label": "input",
-                                                        "opacity": 1,
-                                                        "outline": 0,
-                                                        "padding": 0,
-                                                      }
+                                                        "label": "5",
+                                                        "value": 5,
+                                                      },
+                                                      Object {
+                                                        "label": "20",
+                                                        "value": 20,
+                                                      },
+                                                      Object {
+                                                        "label": "50",
+                                                        "value": 50,
+                                                      },
+                                                    ],
+                                                    "pageSize": 5,
+                                                    "placeholder": "Select...",
+                                                    "screenReaderStatus": [Function],
+                                                    "styles": Object {
+                                                      "clearIndicator": [Function],
+                                                      "container": [Function],
+                                                      "control": [Function],
+                                                      "dropdownIndicator": [Function],
+                                                      "indicatorSeparator": [Function],
+                                                      "indicatorsContainer": [Function],
+                                                      "menu": [Function],
+                                                      "menuList": [Function],
+                                                      "menuPortal": [Function],
+                                                      "option": [Function],
+                                                      "singleValue": [Function],
+                                                      "valueContainer": [Function],
+                                                    },
+                                                    "tabIndex": "0",
+                                                    "tabSelectsValue": true,
+                                                    "value": Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                  }
+                                                }
+                                                setValue={[Function]}
+                                                theme={
+                                                  Object {
+                                                    "borderRadius": 4,
+                                                    "colors": Object {
+                                                      "danger": "#DE350B",
+                                                      "dangerLight": "#FFBDAD",
+                                                      "neutral0": "hsl(0, 0%, 100%)",
+                                                      "neutral10": "hsl(0, 0%, 90%)",
+                                                      "neutral20": "hsl(0, 0%, 80%)",
+                                                      "neutral30": "hsl(0, 0%, 70%)",
+                                                      "neutral40": "hsl(0, 0%, 60%)",
+                                                      "neutral5": "hsl(0, 0%, 95%)",
+                                                      "neutral50": "hsl(0, 0%, 50%)",
+                                                      "neutral60": "hsl(0, 0%, 40%)",
+                                                      "neutral70": "hsl(0, 0%, 30%)",
+                                                      "neutral80": "hsl(0, 0%, 20%)",
+                                                      "neutral90": "hsl(0, 0%, 10%)",
+                                                      "primary": "#2684FF",
+                                                      "primary25": "#DEEBFF",
+                                                      "primary50": "#B2D4FF",
+                                                      "primary75": "#4C9AFF",
+                                                    },
+                                                    "spacing": Object {
+                                                      "baseUnit": 4,
+                                                      "controlHeight": 38,
+                                                      "menuGutter": 8,
+                                                    },
+                                                  }
+                                                }
+                                              >
+                                                <EmotionCssPropInternal
+                                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="SingleValue"
+                                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                  className=""
+                                                  css={
+                                                    Object {
+                                                      "boxSizing": "border-box",
+                                                      "color": "inherit",
+                                                      "label": "singleValue",
+                                                      "marginLeft": 2,
+                                                      "marginRight": 2,
+                                                      "maxWidth": "calc(100% - 8px)",
+                                                      "overflow": "hidden",
+                                                      "position": "absolute",
+                                                      "textOverflow": "ellipsis",
+                                                      "top": "50%",
+                                                      "transform": "translateY(-50%)",
+                                                      "whiteSpace": "nowrap",
                                                     }
-                                                    minWidth={1}
-                                                    onBlur={[Function]}
-                                                    onChange={[Function]}
-                                                    onFocus={[Function]}
-                                                    spellCheck="false"
-                                                    tabIndex="0"
-                                                    type="text"
-                                                    value=""
+                                                  }
+                                                >
+                                                  <div
+                                                    className=" css-1xqm9c7-singleValue"
                                                   >
-                                                    <div
+                                                    5
+                                                  </div>
+                                                </EmotionCssPropInternal>
+                                              </SingleValue>
+                                              <Input
+                                                aria-autocomplete="list"
+                                                autoCapitalize="none"
+                                                autoComplete="off"
+                                                autoCorrect="off"
+                                                cx={[Function]}
+                                                getStyles={[Function]}
+                                                id="react-select-3-input"
+                                                innerRef={[Function]}
+                                                isDisabled={false}
+                                                isHidden={false}
+                                                onBlur={[Function]}
+                                                onChange={[Function]}
+                                                onFocus={[Function]}
+                                                selectProps={
+                                                  Object {
+                                                    "backspaceRemovesValue": true,
+                                                    "blurInputOnSelect": true,
+                                                    "borderless": true,
+                                                    "captureMenuScroll": false,
+                                                    "closeMenuOnScroll": false,
+                                                    "closeMenuOnSelect": true,
+                                                    "components": Object {
+                                                      "DropdownIndicator": [Function],
+                                                      "Option": [Function],
+                                                      "ValueContainer": [Function],
+                                                    },
+                                                    "controlShouldRenderValue": true,
+                                                    "dropdownIcon": undefined,
+                                                    "escapeClearsValue": false,
+                                                    "filterOption": [Function],
+                                                    "formatGroupLabel": [Function],
+                                                    "getOptionLabel": [Function],
+                                                    "getOptionValue": [Function],
+                                                    "hideDropdownIcon": false,
+                                                    "inputIcon": undefined,
+                                                    "inputValue": "",
+                                                    "isDisabled": false,
+                                                    "isLoading": false,
+                                                    "isMulti": false,
+                                                    "isOptionDisabled": [Function],
+                                                    "isRtl": false,
+                                                    "isSearchable": true,
+                                                    "loadingMessage": [Function],
+                                                    "maxMenuHeight": 300,
+                                                    "menuIsOpen": false,
+                                                    "menuPlacement": "auto",
+                                                    "menuPosition": "absolute",
+                                                    "menuShouldBlockScroll": false,
+                                                    "menuShouldScrollIntoView": true,
+                                                    "minMenuHeight": 140,
+                                                    "noOptionsMessage": [Function],
+                                                    "onChange": [Function],
+                                                    "onInputChange": [Function],
+                                                    "onMenuClose": [Function],
+                                                    "onMenuOpen": [Function],
+                                                    "openMenuOnClick": true,
+                                                    "openMenuOnFocus": false,
+                                                    "options": Array [
+                                                      Object {
+                                                        "label": "5",
+                                                        "value": 5,
+                                                      },
+                                                      Object {
+                                                        "label": "20",
+                                                        "value": 20,
+                                                      },
+                                                      Object {
+                                                        "label": "50",
+                                                        "value": 50,
+                                                      },
+                                                    ],
+                                                    "pageSize": 5,
+                                                    "placeholder": "Select...",
+                                                    "screenReaderStatus": [Function],
+                                                    "styles": Object {
+                                                      "clearIndicator": [Function],
+                                                      "container": [Function],
+                                                      "control": [Function],
+                                                      "dropdownIndicator": [Function],
+                                                      "indicatorSeparator": [Function],
+                                                      "indicatorsContainer": [Function],
+                                                      "menu": [Function],
+                                                      "menuList": [Function],
+                                                      "menuPortal": [Function],
+                                                      "option": [Function],
+                                                      "singleValue": [Function],
+                                                      "valueContainer": [Function],
+                                                    },
+                                                    "tabIndex": "0",
+                                                    "tabSelectsValue": true,
+                                                    "value": Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                  }
+                                                }
+                                                spellCheck="false"
+                                                tabIndex="0"
+                                                theme={
+                                                  Object {
+                                                    "borderRadius": 4,
+                                                    "colors": Object {
+                                                      "danger": "#DE350B",
+                                                      "dangerLight": "#FFBDAD",
+                                                      "neutral0": "hsl(0, 0%, 100%)",
+                                                      "neutral10": "hsl(0, 0%, 90%)",
+                                                      "neutral20": "hsl(0, 0%, 80%)",
+                                                      "neutral30": "hsl(0, 0%, 70%)",
+                                                      "neutral40": "hsl(0, 0%, 60%)",
+                                                      "neutral5": "hsl(0, 0%, 95%)",
+                                                      "neutral50": "hsl(0, 0%, 50%)",
+                                                      "neutral60": "hsl(0, 0%, 40%)",
+                                                      "neutral70": "hsl(0, 0%, 30%)",
+                                                      "neutral80": "hsl(0, 0%, 20%)",
+                                                      "neutral90": "hsl(0, 0%, 10%)",
+                                                      "primary": "#2684FF",
+                                                      "primary25": "#DEEBFF",
+                                                      "primary50": "#B2D4FF",
+                                                      "primary75": "#4C9AFF",
+                                                    },
+                                                    "spacing": Object {
+                                                      "baseUnit": 4,
+                                                      "controlHeight": 38,
+                                                      "menuGutter": 8,
+                                                    },
+                                                  }
+                                                }
+                                                type="text"
+                                                value=""
+                                              >
+                                                <EmotionCssPropInternal
+                                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Input"
+                                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
+                                                  css={
+                                                    Object {
+                                                      "boxSizing": "border-box",
+                                                      "color": "hsl(0, 0%, 20%)",
+                                                      "margin": 2,
+                                                      "paddingBottom": 2,
+                                                      "paddingTop": 2,
+                                                      "visibility": "visible",
+                                                    }
+                                                  }
+                                                >
+                                                  <div
+                                                    className="css-b8ldur-Input"
+                                                  >
+                                                    <AutosizeInput
+                                                      aria-autocomplete="list"
+                                                      autoCapitalize="none"
+                                                      autoComplete="off"
+                                                      autoCorrect="off"
                                                       className=""
-                                                      style={
+                                                      disabled={false}
+                                                      id="react-select-3-input"
+                                                      injectStyles={true}
+                                                      inputRef={[Function]}
+                                                      inputStyle={
                                                         Object {
-                                                          "display": "inline-block",
+                                                          "background": 0,
+                                                          "border": 0,
+                                                          "color": "inherit",
+                                                          "fontSize": "inherit",
+                                                          "label": "input",
+                                                          "opacity": 1,
+                                                          "outline": 0,
+                                                          "padding": 0,
                                                         }
                                                       }
+                                                      minWidth={1}
+                                                      onBlur={[Function]}
+                                                      onChange={[Function]}
+                                                      onFocus={[Function]}
+                                                      spellCheck="false"
+                                                      tabIndex="0"
+                                                      type="text"
+                                                      value=""
                                                     >
-                                                      <input
-                                                        aria-autocomplete="list"
-                                                        autoCapitalize="none"
-                                                        autoComplete="off"
-                                                        autoCorrect="off"
-                                                        disabled={false}
-                                                        id="react-select-3-input"
-                                                        onBlur={[Function]}
-                                                        onChange={[Function]}
-                                                        onFocus={[Function]}
-                                                        spellCheck="false"
-                                                        style={
-                                                          Object {
-                                                            "background": 0,
-                                                            "border": 0,
-                                                            "boxSizing": "content-box",
-                                                            "color": "inherit",
-                                                            "fontSize": "inherit",
-                                                            "label": "input",
-                                                            "opacity": 1,
-                                                            "outline": 0,
-                                                            "padding": 0,
-                                                            "width": "2px",
-                                                          }
-                                                        }
-                                                        tabIndex="0"
-                                                        type="text"
-                                                        value=""
-                                                      />
                                                       <div
+                                                        className=""
                                                         style={
                                                           Object {
-                                                            "height": 0,
-                                                            "left": 0,
-                                                            "overflow": "scroll",
-                                                            "position": "absolute",
-                                                            "top": 0,
-                                                            "visibility": "hidden",
-                                                            "whiteSpace": "pre",
+                                                            "display": "inline-block",
                                                           }
                                                         }
-                                                      />
-                                                    </div>
-                                                  </AutosizeInput>
-                                                </div>
-                                              </EmotionCssPropInternal>
-                                            </Input>
-                                          </div>
-                                        </EmotionCssPropInternal>
+                                                      >
+                                                        <input
+                                                          aria-autocomplete="list"
+                                                          autoCapitalize="none"
+                                                          autoComplete="off"
+                                                          autoCorrect="off"
+                                                          disabled={false}
+                                                          id="react-select-3-input"
+                                                          onBlur={[Function]}
+                                                          onChange={[Function]}
+                                                          onFocus={[Function]}
+                                                          spellCheck="false"
+                                                          style={
+                                                            Object {
+                                                              "background": 0,
+                                                              "border": 0,
+                                                              "boxSizing": "content-box",
+                                                              "color": "inherit",
+                                                              "fontSize": "inherit",
+                                                              "label": "input",
+                                                              "opacity": 1,
+                                                              "outline": 0,
+                                                              "padding": 0,
+                                                              "width": "2px",
+                                                            }
+                                                          }
+                                                          tabIndex="0"
+                                                          type="text"
+                                                          value=""
+                                                        />
+                                                        <div
+                                                          style={
+                                                            Object {
+                                                              "height": 0,
+                                                              "left": 0,
+                                                              "overflow": "scroll",
+                                                              "position": "absolute",
+                                                              "top": 0,
+                                                              "visibility": "hidden",
+                                                              "whiteSpace": "pre",
+                                                            }
+                                                          }
+                                                        />
+                                                      </div>
+                                                    </AutosizeInput>
+                                                  </div>
+                                                </EmotionCssPropInternal>
+                                              </Input>
+                                            </div>
+                                          </EmotionCssPropInternal>
+                                        </ValueContainer>
                                       </ValueContainer>
                                       <IndicatorsContainer
                                         clearValue={[Function]}
@@ -10704,15 +11205,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                             "closeMenuOnScroll": false,
                                             "closeMenuOnSelect": true,
                                             "components": Object {
+                                              "DropdownIndicator": [Function],
                                               "Option": [Function],
+                                              "ValueContainer": [Function],
                                             },
                                             "controlShouldRenderValue": true,
+                                            "dropdownIcon": undefined,
                                             "escapeClearsValue": false,
                                             "filterOption": [Function],
                                             "formatGroupLabel": [Function],
                                             "getOptionLabel": [Function],
                                             "getOptionValue": [Function],
-                                            "icon": undefined,
+                                            "hideDropdownIcon": false,
+                                            "inputIcon": undefined,
                                             "inputValue": "",
                                             "isDisabled": false,
                                             "isLoading": false,
@@ -10860,15 +11365,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                   "closeMenuOnScroll": false,
                                                   "closeMenuOnSelect": true,
                                                   "components": Object {
+                                                    "DropdownIndicator": [Function],
                                                     "Option": [Function],
+                                                    "ValueContainer": [Function],
                                                   },
                                                   "controlShouldRenderValue": true,
+                                                  "dropdownIcon": undefined,
                                                   "escapeClearsValue": false,
                                                   "filterOption": [Function],
                                                   "formatGroupLabel": [Function],
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
-                                                  "icon": undefined,
+                                                  "hideDropdownIcon": false,
+                                                  "inputIcon": undefined,
                                                   "inputValue": "",
                                                   "isDisabled": false,
                                                   "isLoading": false,
@@ -10976,7 +11485,7 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                 />
                                               </EmotionCssPropInternal>
                                             </IndicatorSeparator>
-                                            <DropdownIndicator
+                                            <LUKDropdownIndicator
                                               clearValue={[Function]}
                                               cx={[Function]}
                                               getStyles={[Function]}
@@ -11019,15 +11528,19 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                   "closeMenuOnScroll": false,
                                                   "closeMenuOnSelect": true,
                                                   "components": Object {
+                                                    "DropdownIndicator": [Function],
                                                     "Option": [Function],
+                                                    "ValueContainer": [Function],
                                                   },
                                                   "controlShouldRenderValue": true,
+                                                  "dropdownIcon": undefined,
                                                   "escapeClearsValue": false,
                                                   "filterOption": [Function],
                                                   "formatGroupLabel": [Function],
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
-                                                  "icon": undefined,
+                                                  "hideDropdownIcon": false,
+                                                  "inputIcon": undefined,
                                                   "inputValue": "",
                                                   "isDisabled": false,
                                                   "isLoading": false,
@@ -11120,66 +11633,215 @@ exports[`Table handlePageChange should invoke onPageChange on rows per page sele
                                                 }
                                               }
                                             >
-                                              <EmotionCssPropInternal
-                                                __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
-                                                __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-                                                aria-hidden="true"
-                                                className=""
-                                                css={
+                                              <DropdownIndicator
+                                                clearValue={[Function]}
+                                                cx={[Function]}
+                                                getStyles={[Function]}
+                                                getValue={[Function]}
+                                                hasValue={true}
+                                                innerProps={
                                                   Object {
-                                                    "color": "#b6bbc7",
-                                                    "display": "flex",
-                                                    "margin": "5px",
-                                                    "padding": "0",
+                                                    "aria-hidden": "true",
+                                                    "onMouseDown": [Function],
+                                                    "onTouchEnd": [Function],
                                                   }
                                                 }
-                                                onMouseDown={[Function]}
-                                                onTouchEnd={[Function]}
+                                                isDisabled={false}
+                                                isFocused={false}
+                                                isMulti={false}
+                                                isRtl={false}
+                                                options={
+                                                  Array [
+                                                    Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                    Object {
+                                                      "label": "20",
+                                                      "value": 20,
+                                                    },
+                                                    Object {
+                                                      "label": "50",
+                                                      "value": 50,
+                                                    },
+                                                  ]
+                                                }
+                                                selectOption={[Function]}
+                                                selectProps={
+                                                  Object {
+                                                    "backspaceRemovesValue": true,
+                                                    "blurInputOnSelect": true,
+                                                    "borderless": true,
+                                                    "captureMenuScroll": false,
+                                                    "closeMenuOnScroll": false,
+                                                    "closeMenuOnSelect": true,
+                                                    "components": Object {
+                                                      "DropdownIndicator": [Function],
+                                                      "Option": [Function],
+                                                      "ValueContainer": [Function],
+                                                    },
+                                                    "controlShouldRenderValue": true,
+                                                    "dropdownIcon": undefined,
+                                                    "escapeClearsValue": false,
+                                                    "filterOption": [Function],
+                                                    "formatGroupLabel": [Function],
+                                                    "getOptionLabel": [Function],
+                                                    "getOptionValue": [Function],
+                                                    "hideDropdownIcon": false,
+                                                    "inputIcon": undefined,
+                                                    "inputValue": "",
+                                                    "isDisabled": false,
+                                                    "isLoading": false,
+                                                    "isMulti": false,
+                                                    "isOptionDisabled": [Function],
+                                                    "isRtl": false,
+                                                    "isSearchable": true,
+                                                    "loadingMessage": [Function],
+                                                    "maxMenuHeight": 300,
+                                                    "menuIsOpen": false,
+                                                    "menuPlacement": "auto",
+                                                    "menuPosition": "absolute",
+                                                    "menuShouldBlockScroll": false,
+                                                    "menuShouldScrollIntoView": true,
+                                                    "minMenuHeight": 140,
+                                                    "noOptionsMessage": [Function],
+                                                    "onChange": [Function],
+                                                    "onInputChange": [Function],
+                                                    "onMenuClose": [Function],
+                                                    "onMenuOpen": [Function],
+                                                    "openMenuOnClick": true,
+                                                    "openMenuOnFocus": false,
+                                                    "options": Array [
+                                                      Object {
+                                                        "label": "5",
+                                                        "value": 5,
+                                                      },
+                                                      Object {
+                                                        "label": "20",
+                                                        "value": 20,
+                                                      },
+                                                      Object {
+                                                        "label": "50",
+                                                        "value": 50,
+                                                      },
+                                                    ],
+                                                    "pageSize": 5,
+                                                    "placeholder": "Select...",
+                                                    "screenReaderStatus": [Function],
+                                                    "styles": Object {
+                                                      "clearIndicator": [Function],
+                                                      "container": [Function],
+                                                      "control": [Function],
+                                                      "dropdownIndicator": [Function],
+                                                      "indicatorSeparator": [Function],
+                                                      "indicatorsContainer": [Function],
+                                                      "menu": [Function],
+                                                      "menuList": [Function],
+                                                      "menuPortal": [Function],
+                                                      "option": [Function],
+                                                      "singleValue": [Function],
+                                                      "valueContainer": [Function],
+                                                    },
+                                                    "tabIndex": "0",
+                                                    "tabSelectsValue": true,
+                                                    "value": Object {
+                                                      "label": "5",
+                                                      "value": 5,
+                                                    },
+                                                  }
+                                                }
+                                                setValue={[Function]}
+                                                theme={
+                                                  Object {
+                                                    "borderRadius": 4,
+                                                    "colors": Object {
+                                                      "danger": "#DE350B",
+                                                      "dangerLight": "#FFBDAD",
+                                                      "neutral0": "hsl(0, 0%, 100%)",
+                                                      "neutral10": "hsl(0, 0%, 90%)",
+                                                      "neutral20": "hsl(0, 0%, 80%)",
+                                                      "neutral30": "hsl(0, 0%, 70%)",
+                                                      "neutral40": "hsl(0, 0%, 60%)",
+                                                      "neutral5": "hsl(0, 0%, 95%)",
+                                                      "neutral50": "hsl(0, 0%, 50%)",
+                                                      "neutral60": "hsl(0, 0%, 40%)",
+                                                      "neutral70": "hsl(0, 0%, 30%)",
+                                                      "neutral80": "hsl(0, 0%, 20%)",
+                                                      "neutral90": "hsl(0, 0%, 10%)",
+                                                      "primary": "#2684FF",
+                                                      "primary25": "#DEEBFF",
+                                                      "primary50": "#B2D4FF",
+                                                      "primary75": "#4C9AFF",
+                                                    },
+                                                    "spacing": Object {
+                                                      "baseUnit": 4,
+                                                      "controlHeight": 38,
+                                                      "menuGutter": 8,
+                                                    },
+                                                  }
+                                                }
                                               >
-                                                <div
+                                                <EmotionCssPropInternal
+                                                  __EMOTION_LABEL_PLEASE_DO_NOT_USE__="DropdownIndicator"
+                                                  __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
                                                   aria-hidden="true"
-                                                  className=" css-1vd5qh6-DropdownIndicator"
+                                                  className=""
+                                                  css={
+                                                    Object {
+                                                      "color": "#b6bbc7",
+                                                      "display": "flex",
+                                                      "margin": "5px",
+                                                      "padding": "0",
+                                                    }
+                                                  }
                                                   onMouseDown={[Function]}
                                                   onTouchEnd={[Function]}
                                                 >
-                                                  <DownChevron>
-                                                    <Svg
-                                                      size={20}
-                                                    >
-                                                      <EmotionCssPropInternal
-                                                        __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
-                                                        __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
-                                                        aria-hidden="true"
-                                                        css={
-                                                          Object {
-                                                            "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
-                                                            "name": "19bqh2r",
-                                                            "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
-                                                          }
-                                                        }
-                                                        focusable="false"
-                                                        height={20}
-                                                        viewBox="0 0 20 20"
-                                                        width={20}
+                                                  <div
+                                                    aria-hidden="true"
+                                                    className=" css-1vd5qh6-DropdownIndicator"
+                                                    onMouseDown={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                  >
+                                                    <DownChevron>
+                                                      <Svg
+                                                        size={20}
                                                       >
-                                                        <svg
+                                                        <EmotionCssPropInternal
+                                                          __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Svg"
+                                                          __EMOTION_TYPE_PLEASE_DO_NOT_USE__="svg"
                                                           aria-hidden="true"
-                                                          className="css-6q0nyr-Svg"
+                                                          css={
+                                                            Object {
+                                                              "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluZGljYXRvcnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBa0JJIiwiZmlsZSI6ImluZGljYXRvcnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuLyoqIEBqc3gganN4ICovXG5pbXBvcnQgeyB0eXBlIE5vZGUgfSBmcm9tICdyZWFjdCc7XG5pbXBvcnQgeyBqc3gsIGtleWZyYW1lcyB9IGZyb20gJ0BlbW90aW9uL2NvcmUnO1xuXG5pbXBvcnQgdHlwZSB7IENvbW1vblByb3BzLCBUaGVtZSB9IGZyb20gJy4uL3R5cGVzJztcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBEcm9wZG93biAmIENsZWFyIEljb25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgU3ZnID0gKHsgc2l6ZSwgLi4ucHJvcHMgfTogeyBzaXplOiBudW1iZXIgfSkgPT4gKFxuICA8c3ZnXG4gICAgaGVpZ2h0PXtzaXplfVxuICAgIHdpZHRoPXtzaXplfVxuICAgIHZpZXdCb3g9XCIwIDAgMjAgMjBcIlxuICAgIGFyaWEtaGlkZGVuPVwidHJ1ZVwiXG4gICAgZm9jdXNhYmxlPVwiZmFsc2VcIlxuICAgIGNzcz17e1xuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBmaWxsOiAnY3VycmVudENvbG9yJyxcbiAgICAgIGxpbmVIZWlnaHQ6IDEsXG4gICAgICBzdHJva2U6ICdjdXJyZW50Q29sb3InLFxuICAgICAgc3Ryb2tlV2lkdGg6IDAsXG4gICAgfX1cbiAgICB7Li4ucHJvcHN9XG4gIC8+XG4pO1xuXG5leHBvcnQgY29uc3QgQ3Jvc3NJY29uID0gKHByb3BzOiBhbnkpID0+IChcbiAgPFN2ZyBzaXplPXsyMH0gey4uLnByb3BzfT5cbiAgICA8cGF0aCBkPVwiTTE0LjM0OCAxNC44NDljLTAuNDY5IDAuNDY5LTEuMjI5IDAuNDY5LTEuNjk3IDBsLTIuNjUxLTMuMDMwLTIuNjUxIDMuMDI5Yy0wLjQ2OSAwLjQ2OS0xLjIyOSAwLjQ2OS0xLjY5NyAwLTAuNDY5LTAuNDY5LTAuNDY5LTEuMjI5IDAtMS42OTdsMi43NTgtMy4xNS0yLjc1OS0zLjE1MmMtMC40NjktMC40NjktMC40NjktMS4yMjggMC0xLjY5N3MxLjIyOC0wLjQ2OSAxLjY5NyAwbDIuNjUyIDMuMDMxIDIuNjUxLTMuMDMxYzAuNDY5LTAuNDY5IDEuMjI4LTAuNDY5IDEuNjk3IDBzMC40NjkgMS4yMjkgMCAxLjY5N2wtMi43NTggMy4xNTIgMi43NTggMy4xNWMwLjQ2OSAwLjQ2OSAwLjQ2OSAxLjIyOSAwIDEuNjk4elwiIC8+XG4gIDwvU3ZnPlxuKTtcbmV4cG9ydCBjb25zdCBEb3duQ2hldnJvbiA9IChwcm9wczogYW55KSA9PiAoXG4gIDxTdmcgc2l6ZT17MjB9IHsuLi5wcm9wc30+XG4gICAgPHBhdGggZD1cIk00LjUxNiA3LjU0OGMwLjQzNi0wLjQ0NiAxLjA0My0wLjQ4MSAxLjU3NiAwbDMuOTA4IDMuNzQ3IDMuOTA4LTMuNzQ3YzAuNTMzLTAuNDgxIDEuMTQxLTAuNDQ2IDEuNTc0IDAgMC40MzYgMC40NDUgMC40MDggMS4xOTcgMCAxLjYxNS0wLjQwNiAwLjQxOC00LjY5NSA0LjUwMi00LjY5NSA0LjUwMi0wLjIxNyAwLjIyMy0wLjUwMiAwLjMzNS0wLjc4NyAwLjMzNXMtMC41Ny0wLjExMi0wLjc4OS0wLjMzNWMwIDAtNC4yODctNC4wODQtNC42OTUtNC41MDJzLTAuNDM2LTEuMTcgMC0xLjYxNXpcIiAvPlxuICA8L1N2Zz5cbik7XG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRHJvcGRvd24gJiBDbGVhciBCdXR0b25zXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuZXhwb3J0IHR5cGUgSW5kaWNhdG9yUHJvcHMgPSBDb21tb25Qcm9wcyAmIHtcbiAgLyoqIFRoZSBjaGlsZHJlbiB0byBiZSByZW5kZXJlZCBpbnNpZGUgdGhlIGluZGljYXRvci4gKi9cbiAgY2hpbGRyZW46IE5vZGUsXG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufTtcblxuY29uc3QgYmFzZUNTUyA9ICh7XG4gIGlzRm9jdXNlZCxcbiAgdGhlbWU6IHtcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gICAgY29sb3JzLFxuICB9LFxufTogSW5kaWNhdG9yUHJvcHMpID0+ICh7XG4gIGxhYmVsOiAnaW5kaWNhdG9yQ29udGFpbmVyJyxcbiAgY29sb3I6IGlzRm9jdXNlZCA/IGNvbG9ycy5uZXV0cmFsNjAgOiBjb2xvcnMubmV1dHJhbDIwLFxuICBkaXNwbGF5OiAnZmxleCcsXG4gIHBhZGRpbmc6IGJhc2VVbml0ICogMixcbiAgdHJhbnNpdGlvbjogJ2NvbG9yIDE1MG1zJyxcblxuICAnOmhvdmVyJzoge1xuICAgIGNvbG9yOiBpc0ZvY3VzZWQgPyBjb2xvcnMubmV1dHJhbDgwIDogY29sb3JzLm5ldXRyYWw0MCxcbiAgfSxcbn0pO1xuXG5leHBvcnQgY29uc3QgZHJvcGRvd25JbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IERyb3Bkb3duSW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2Ryb3Bkb3duSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnZHJvcGRvd24taW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8RG93bkNoZXZyb24gLz59XG4gICAgPC9kaXY+XG4gICk7XG59O1xuXG5leHBvcnQgY29uc3QgY2xlYXJJbmRpY2F0b3JDU1MgPSBiYXNlQ1NTO1xuZXhwb3J0IGNvbnN0IENsZWFySW5kaWNhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNoaWxkcmVuLCBjbGFzc05hbWUsIGN4LCBnZXRTdHlsZXMsIGlubmVyUHJvcHMgfSA9IHByb3BzO1xuICByZXR1cm4gKFxuICAgIDxkaXZcbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2NsZWFySW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnY2xlYXItaW5kaWNhdG9yJzogdHJ1ZSxcbiAgICAgICAgfSxcbiAgICAgICAgY2xhc3NOYW1lXG4gICAgICApfVxuICAgID5cbiAgICAgIHtjaGlsZHJlbiB8fCA8Q3Jvc3NJY29uIC8+fVxuICAgIDwvZGl2PlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBTZXBhcmF0b3Jcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG50eXBlIFNlcGFyYXRvclN0YXRlID0geyBpc0Rpc2FibGVkOiBib29sZWFuIH07XG5cbmV4cG9ydCBjb25zdCBpbmRpY2F0b3JTZXBhcmF0b3JDU1MgPSAoe1xuICBpc0Rpc2FibGVkLFxuICB0aGVtZToge1xuICAgIHNwYWNpbmc6IHsgYmFzZVVuaXQgfSxcbiAgICBjb2xvcnMsXG4gIH0sXG59OiBDb21tb25Qcm9wcyAmIFNlcGFyYXRvclN0YXRlKSA9PiAoe1xuICBsYWJlbDogJ2luZGljYXRvclNlcGFyYXRvcicsXG4gIGFsaWduU2VsZjogJ3N0cmV0Y2gnLFxuICBiYWNrZ3JvdW5kQ29sb3I6IGlzRGlzYWJsZWQgPyBjb2xvcnMubmV1dHJhbDEwIDogY29sb3JzLm5ldXRyYWwyMCxcbiAgbWFyZ2luQm90dG9tOiBiYXNlVW5pdCAqIDIsXG4gIG1hcmdpblRvcDogYmFzZVVuaXQgKiAyLFxuICB3aWR0aDogMSxcbn0pO1xuXG5leHBvcnQgY29uc3QgSW5kaWNhdG9yU2VwYXJhdG9yID0gKHByb3BzOiBJbmRpY2F0b3JQcm9wcykgPT4ge1xuICBjb25zdCB7IGNsYXNzTmFtZSwgY3gsIGdldFN0eWxlcywgaW5uZXJQcm9wcyB9ID0gcHJvcHM7XG4gIHJldHVybiAoXG4gICAgPHNwYW5cbiAgICAgIHsuLi5pbm5lclByb3BzfVxuICAgICAgY3NzPXtnZXRTdHlsZXMoJ2luZGljYXRvclNlcGFyYXRvcicsIHByb3BzKX1cbiAgICAgIGNsYXNzTmFtZT17Y3goeyAnaW5kaWNhdG9yLXNlcGFyYXRvcic6IHRydWUgfSwgY2xhc3NOYW1lKX1cbiAgICAvPlxuICApO1xufTtcblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBMb2FkaW5nXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuY29uc3QgbG9hZGluZ0RvdEFuaW1hdGlvbnMgPSBrZXlmcmFtZXNgXG4gIDAlLCA4MCUsIDEwMCUgeyBvcGFjaXR5OiAwOyB9XG4gIDQwJSB7IG9wYWNpdHk6IDE7IH1cbmA7XG5cbmV4cG9ydCBjb25zdCBsb2FkaW5nSW5kaWNhdG9yQ1NTID0gKHtcbiAgaXNGb2N1c2VkLFxuICBzaXplLFxuICB0aGVtZToge1xuICAgIGNvbG9ycyxcbiAgICBzcGFjaW5nOiB7IGJhc2VVbml0IH0sXG4gIH0sXG59OiB7XG4gIGlzRm9jdXNlZDogYm9vbGVhbixcbiAgc2l6ZTogbnVtYmVyLFxuICB0aGVtZTogVGhlbWUsXG59KSA9PiAoe1xuICBsYWJlbDogJ2xvYWRpbmdJbmRpY2F0b3InLFxuICBjb2xvcjogaXNGb2N1c2VkID8gY29sb3JzLm5ldXRyYWw2MCA6IGNvbG9ycy5uZXV0cmFsMjAsXG4gIGRpc3BsYXk6ICdmbGV4JyxcbiAgcGFkZGluZzogYmFzZVVuaXQgKiAyLFxuICB0cmFuc2l0aW9uOiAnY29sb3IgMTUwbXMnLFxuICBhbGlnblNlbGY6ICdjZW50ZXInLFxuICBmb250U2l6ZTogc2l6ZSxcbiAgbGluZUhlaWdodDogMSxcbiAgbWFyZ2luUmlnaHQ6IHNpemUsXG4gIHRleHRBbGlnbjogJ2NlbnRlcicsXG4gIHZlcnRpY2FsQWxpZ246ICdtaWRkbGUnLFxufSk7XG5cbnR5cGUgRG90UHJvcHMgPSB7IGRlbGF5OiBudW1iZXIsIG9mZnNldDogYm9vbGVhbiB9O1xuY29uc3QgTG9hZGluZ0RvdCA9ICh7IGRlbGF5LCBvZmZzZXQgfTogRG90UHJvcHMpID0+IChcbiAgPHNwYW5cbiAgICBjc3M9e3tcbiAgICAgIGFuaW1hdGlvbjogYCR7bG9hZGluZ0RvdEFuaW1hdGlvbnN9IDFzIGVhc2UtaW4tb3V0ICR7ZGVsYXl9bXMgaW5maW5pdGU7YCxcbiAgICAgIGJhY2tncm91bmRDb2xvcjogJ2N1cnJlbnRDb2xvcicsXG4gICAgICBib3JkZXJSYWRpdXM6ICcxZW0nLFxuICAgICAgZGlzcGxheTogJ2lubGluZS1ibG9jaycsXG4gICAgICBtYXJnaW5MZWZ0OiBvZmZzZXQgPyAnMWVtJyA6IG51bGwsXG4gICAgICBoZWlnaHQ6ICcxZW0nLFxuICAgICAgdmVydGljYWxBbGlnbjogJ3RvcCcsXG4gICAgICB3aWR0aDogJzFlbScsXG4gICAgfX1cbiAgLz5cbik7XG5cbmV4cG9ydCB0eXBlIExvYWRpbmdJY29uUHJvcHMgPSB7XG4gIC8qKiBQcm9wcyB0aGF0IHdpbGwgYmUgcGFzc2VkIG9uIHRvIHRoZSBjaGlsZHJlbi4gKi9cbiAgaW5uZXJQcm9wczogYW55LFxuICAvKiogVGhlIGZvY3VzZWQgc3RhdGUgb2YgdGhlIHNlbGVjdC4gKi9cbiAgaXNGb2N1c2VkOiBib29sZWFuLFxuICAvKiogV2hldGhlciB0aGUgdGV4dCBpcyByaWdodCB0byBsZWZ0ICovXG4gIGlzUnRsOiBib29sZWFuLFxufSAmIENvbW1vblByb3BzICYge1xuICAgIC8qKiBTZXQgc2l6ZSBvZiB0aGUgY29udGFpbmVyLiAqL1xuICAgIHNpemU6IG51bWJlcixcbiAgfTtcbmV4cG9ydCBjb25zdCBMb2FkaW5nSW5kaWNhdG9yID0gKHByb3BzOiBMb2FkaW5nSWNvblByb3BzKSA9PiB7XG4gIGNvbnN0IHsgY2xhc3NOYW1lLCBjeCwgZ2V0U3R5bGVzLCBpbm5lclByb3BzLCBpc1J0bCB9ID0gcHJvcHM7XG5cbiAgcmV0dXJuIChcbiAgICA8ZGl2XG4gICAgICB7Li4uaW5uZXJQcm9wc31cbiAgICAgIGNzcz17Z2V0U3R5bGVzKCdsb2FkaW5nSW5kaWNhdG9yJywgcHJvcHMpfVxuICAgICAgY2xhc3NOYW1lPXtjeChcbiAgICAgICAge1xuICAgICAgICAgIGluZGljYXRvcjogdHJ1ZSxcbiAgICAgICAgICAnbG9hZGluZy1pbmRpY2F0b3InOiB0cnVlLFxuICAgICAgICB9LFxuICAgICAgICBjbGFzc05hbWVcbiAgICAgICl9XG4gICAgPlxuICAgICAgPExvYWRpbmdEb3QgZGVsYXk9ezB9IG9mZnNldD17aXNSdGx9IC8+XG4gICAgICA8TG9hZGluZ0RvdCBkZWxheT17MTYwfSBvZmZzZXQgLz5cbiAgICAgIDxMb2FkaW5nRG90IGRlbGF5PXszMjB9IG9mZnNldD17IWlzUnRsfSAvPlxuICAgIDwvZGl2PlxuICApO1xufTtcbkxvYWRpbmdJbmRpY2F0b3IuZGVmYXVsdFByb3BzID0geyBzaXplOiA0IH07XG4iXX0= */",
+                                                              "name": "19bqh2r",
+                                                              "styles": "display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;",
+                                                            }
+                                                          }
                                                           focusable="false"
                                                           height={20}
                                                           viewBox="0 0 20 20"
                                                           width={20}
                                                         >
-                                                          <path
-                                                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                                                          />
-                                                        </svg>
-                                                      </EmotionCssPropInternal>
-                                                    </Svg>
-                                                  </DownChevron>
-                                                </div>
-                                              </EmotionCssPropInternal>
-                                            </DropdownIndicator>
+                                                          <svg
+                                                            aria-hidden="true"
+                                                            className="css-6q0nyr-Svg"
+                                                            focusable="false"
+                                                            height={20}
+                                                            viewBox="0 0 20 20"
+                                                            width={20}
+                                                          >
+                                                            <path
+                                                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                                                            />
+                                                          </svg>
+                                                        </EmotionCssPropInternal>
+                                                      </Svg>
+                                                    </DownChevron>
+                                                  </div>
+                                                </EmotionCssPropInternal>
+                                              </DropdownIndicator>
+                                            </LUKDropdownIndicator>
                                           </div>
                                         </EmotionCssPropInternal>
                                       </IndicatorsContainer>


### PR DESCRIPTION
# Changes
- Add `inputIcon`, `dropdownIcon`, and `hideDropdownIcon` props 🎉 
- fix user supplied `components` not merging with LUK default components properly.
- decrease font-size of select options to `0.875rem` (14px)

![image](https://user-images.githubusercontent.com/27182199/79685485-0ee04600-81ee-11ea-8013-53f25501817b.png)

# Deprecated
- `icon` prop on all `<Select />` variations have been deprecated. Use `dropdownIcon` which accepts React.Node. Using the `icon` prop will trigger a warning in the console. While supplying a FontAwesome IconDefinition or functional component will still work, this will be removed in future versions.


