### PR TITLE
fix inputIcon hiding truncation of input values

### DIFF
--- a/src/style/select/singleValueStyles.js
+++ b/src/style/select/singleValueStyles.js
@@ -1,4 +1,17 @@
 import { NEUTRALS } from '../../colors/src/Colors';
 
-const singleValueStyles = (base, state) => ({ ...base, color: state.isDisabled ? NEUTRALS[1] : 'inherit' });
+const singleValueStyles = (base, state) => {
+  const { selectProps } = state;
+
+  const styles = {
+    ...base,
+    color: state.isDisabled ? NEUTRALS[1] : 'inherit',
+  };
+
+  if (selectProps && selectProps.inputIcon) {
+    styles.maxWidth = 'calc(100% - 32px)';
+  }
+
+  return styles;
+};
 export default singleValueStyles;


### PR DESCRIPTION
- Shrink singleInputValue by the same width of the icon padding