### PR TITLE
Bugfix/APPS-2101 fix orgs select

### DIFF
--- a/src/components/search/src/components/__snapshots__/Search.test.js.snap
+++ b/src/components/search/src/components/__snapshots__/Search.test.js.snap
@@ -1918,7 +1918,7 @@ exports[`Search snapshots should match snapshot 1`] = `
                                                                                           }
                                                                                         >
                                                                                           <svg
-                                                                                            aria-hidden="true"
+                                                                                            aria-hidden={true}
                                                                                             className="MuiSvgIcon-root"
                                                                                             focusable="false"
                                                                                             viewBox="0 0 24 24"

--- a/src/datetime/src/components/__snapshots__/DatePicker.test.js.snap
+++ b/src/datetime/src/components/__snapshots__/DatePicker.test.js.snap
@@ -999,7 +999,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                                                             }
                                                           >
                                                             <svg
-                                                              aria-hidden="true"
+                                                              aria-hidden={true}
                                                               className="MuiSvgIcon-root"
                                                               focusable="false"
                                                               viewBox="0 0 24 24"

--- a/src/datetime/src/components/__snapshots__/DateTimePicker.test.js.snap
+++ b/src/datetime/src/components/__snapshots__/DateTimePicker.test.js.snap
@@ -1012,7 +1012,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                                                             }
                                                           >
                                                             <svg
-                                                              aria-hidden="true"
+                                                              aria-hidden={true}
                                                               className="MuiSvgIcon-root"
                                                               focusable="false"
                                                               viewBox="0 0 24 24"

--- a/src/layout/src/components/App/AppHeaderWrapper.js
+++ b/src/layout/src/components/App/AppHeaderWrapper.js
@@ -346,20 +346,22 @@ class AppHeaderWrapper extends Component<Props, State> {
     const { handleNavigationWrapping, shouldForceDrawer } = this.state;
 
     let organizations = [];
-    if (isArray(organizationsSelect.organizations) || isPlainObject(organizationsSelect.organizations)) {
-      organizations = Object.values(organizationsSelect.organizations);
-    }
-    else if (isCollection(organizationsSelect.organizations)) {
-      organizations = organizationsSelect.organizations.valueSeq();
-    }
-
     const organizationOptions = [];
-    organizations.forEach((organization) => {
-      organizationOptions.push({
-        label: get(organization, 'title'),
-        value: get(organization, 'id'),
+    if (organizationsSelect !== undefined) {
+      if (isArray(organizationsSelect.organizations) || isPlainObject(organizationsSelect.organizations)) {
+        organizations = Object.values(organizationsSelect.organizations);
+      }
+      else if (isCollection(organizationsSelect.organizations)) {
+        organizations = organizationsSelect.organizations.valueSeq();
+      }
+
+      organizations.forEach((organization) => {
+        organizationOptions.push({
+          label: get(organization, 'title'),
+          value: get(organization, 'id'),
+        });
       });
-    });
+    }
 
     const selectedOrganizationOption = organizationOptions.find((option) => (
       option.value === organizationsSelect.selectedOrganizationId

--- a/src/layout/src/components/App/AppHeaderWrapper.js
+++ b/src/layout/src/components/App/AppHeaderWrapper.js
@@ -148,7 +148,7 @@ class AppHeaderWrapper extends Component<Props, State> {
   static defaultProps = {
     className: undefined,
     logout: undefined,
-    organizationsSelect: {},
+    organizationsSelect: undefined,
     user: undefined,
   }
 
@@ -369,7 +369,7 @@ class AppHeaderWrapper extends Component<Props, State> {
       return (
         <HeaderSectionContentWrapper align="right" ref={this.rightRef}>
           {
-            organizationOptions.length > 0 && (
+            organizationsSelect !== undefined && (
               <Select
                   isClearable={false}
                   isDisabled={organizationsSelect.isDisabled}
@@ -398,7 +398,7 @@ class AppHeaderWrapper extends Component<Props, State> {
           )
         }
         {
-          organizationOptions.length > 0 && (
+          organizationsSelect !== undefined && (
             <Select
                 isClearable={false}
                 isDisabled={organizationsSelect.isDisabled}

--- a/src/layout/src/components/App/AppHeaderWrapper.js
+++ b/src/layout/src/components/App/AppHeaderWrapper.js
@@ -347,7 +347,7 @@ class AppHeaderWrapper extends Component<Props, State> {
 
     let organizations = [];
     const organizationOptions = [];
-    if (organizationsSelect !== undefined) {
+    if (organizationsSelect) {
       if (isArray(organizationsSelect.organizations) || isPlainObject(organizationsSelect.organizations)) {
         organizations = Object.values(organizationsSelect.organizations);
       }
@@ -371,7 +371,7 @@ class AppHeaderWrapper extends Component<Props, State> {
       return (
         <HeaderSectionContentWrapper align="right" ref={this.rightRef}>
           {
-            organizationsSelect !== undefined && (
+            organizationsSelect && (
               <Select
                   isClearable={false}
                   isDisabled={organizationsSelect.isDisabled}
@@ -400,7 +400,7 @@ class AppHeaderWrapper extends Component<Props, State> {
           )
         }
         {
-          organizationsSelect !== undefined && (
+          organizationsSelect && (
             <Select
                 isClearable={false}
                 isDisabled={organizationsSelect.isDisabled}


### PR DESCRIPTION
Organizations select should be rendered if the `organizationsSelect` prop is passed to the AppHeaderWrapper, even if there aren't any orgs found. That way, the spinner can be rendered while request for organizations is pending.

Default of `organizationsSelect` is now `undefined`.