### PR TITLE
hotfix/APPS-2101 — fix organizations select

### DIFF
--- a/src/components/search/src/components/__snapshots__/Search.test.js.snap
+++ b/src/components/search/src/components/__snapshots__/Search.test.js.snap
@@ -1639,7 +1639,7 @@ exports[`Search snapshots should match snapshot 1`] = `
                                                                                           }
                                                                                         >
                                                                                           <svg
-                                                                                            aria-hidden="true"
+                                                                                            aria-hidden={true}
                                                                                             className="MuiSvgIcon-root"
                                                                                             focusable="false"
                                                                                             viewBox="0 0 24 24"

--- a/src/datetime/src/components/__snapshots__/DatePicker.test.js.snap
+++ b/src/datetime/src/components/__snapshots__/DatePicker.test.js.snap
@@ -931,7 +931,7 @@ exports[`DatePicker render matches snapshot 1`] = `
                                                             }
                                                           >
                                                             <svg
-                                                              aria-hidden="true"
+                                                              aria-hidden={true}
                                                               className="MuiSvgIcon-root"
                                                               focusable="false"
                                                               viewBox="0 0 24 24"

--- a/src/datetime/src/components/__snapshots__/DateTimePicker.test.js.snap
+++ b/src/datetime/src/components/__snapshots__/DateTimePicker.test.js.snap
@@ -944,7 +944,7 @@ exports[`DateTimePicker render matches snapshot 1`] = `
                                                             }
                                                           >
                                                             <svg
-                                                              aria-hidden="true"
+                                                              aria-hidden={true}
                                                               className="MuiSvgIcon-root"
                                                               focusable="false"
                                                               viewBox="0 0 24 24"

--- a/src/layout/src/components/App/AppHeaderWrapper.js
+++ b/src/layout/src/components/App/AppHeaderWrapper.js
@@ -148,7 +148,7 @@ class AppHeaderWrapper extends Component<Props, State> {
   static defaultProps = {
     className: undefined,
     logout: undefined,
-    organizationsSelect: {},
+    organizationsSelect: undefined,
     user: undefined,
   }
 
@@ -346,20 +346,22 @@ class AppHeaderWrapper extends Component<Props, State> {
     const { handleNavigationWrapping, shouldForceDrawer } = this.state;
 
     let organizations = [];
-    if (isArray(organizationsSelect.organizations) || isPlainObject(organizationsSelect.organizations)) {
-      organizations = Object.values(organizationsSelect.organizations);
-    }
-    else if (isCollection(organizationsSelect.organizations)) {
-      organizations = organizationsSelect.organizations.valueSeq();
-    }
-
     const organizationOptions = [];
-    organizations.forEach((organization) => {
-      organizationOptions.push({
-        label: get(organization, 'title'),
-        value: get(organization, 'id'),
+    if (organizationsSelect) {
+      if (isArray(organizationsSelect.organizations) || isPlainObject(organizationsSelect.organizations)) {
+        organizations = Object.values(organizationsSelect.organizations);
+      }
+      else if (isCollection(organizationsSelect.organizations)) {
+        organizations = organizationsSelect.organizations.valueSeq();
+      }
+
+      organizations.forEach((organization) => {
+        organizationOptions.push({
+          label: get(organization, 'title'),
+          value: get(organization, 'id'),
+        });
       });
-    });
+    }
 
     const selectedOrganizationOption = organizationOptions.find((option) => (
       option.value === organizationsSelect.selectedOrganizationId
@@ -369,7 +371,7 @@ class AppHeaderWrapper extends Component<Props, State> {
       return (
         <HeaderSectionContentWrapper align="right" ref={this.rightRef}>
           {
-            organizationOptions.length > 0 && (
+            organizationsSelect && (
               <Select
                   isClearable={false}
                   isDisabled={organizationsSelect.isDisabled}
@@ -398,7 +400,7 @@ class AppHeaderWrapper extends Component<Props, State> {
           )
         }
         {
-          organizationOptions.length > 0 && (
+          organizationsSelect && (
             <Select
                 isClearable={false}
                 isDisabled={organizationsSelect.isDisabled}


### PR DESCRIPTION
Organizations select should be rendered if the `organizationsSelect` prop is passed to the AppHeaderWrapper, even if there aren't any orgs found. That way, the spinner can be rendered while request for organizations is pending.

Default of `organizationsSelect` is now undefined.