### PR TITLE
checkbox forwardRef

### DIFF
--- a/src/choices/src/components/Checkbox.js
+++ b/src/choices/src/components/Checkbox.js
@@ -10,6 +10,8 @@ import {
   ChoiceWrapper,
 } from './styled';
 
+import { stopPropagation } from '../../../utils';
+
 type Props = {|
   checked ?:boolean;
   defaultChecked ?:boolean;
@@ -45,6 +47,7 @@ const Checkbox = ({
             disabled={disabled || readOnly}
             {...rest}
             ref={forwardedRef} />
+        <CheckboxIndicator mode={mode} onClick={stopPropagation}>
           { mode === 'button' && label }
         </CheckboxIndicator>
       </ChoiceInnerWrapper>

--- a/src/choices/src/components/Checkbox.js
+++ b/src/choices/src/components/Checkbox.js
@@ -11,23 +11,25 @@ import {
 } from './styled';
 
 type Props = {|
-  checked ? :boolean;
-  defaultChecked ? :boolean;
-  disabled ? :boolean;
-  id ? :string;
-  label ? :string;
-  mode ? :string;
-  name ? :string;
-  onBlur ? :(event :SyntheticFocusEvent<HTMLInputElement>) => void;
-  onChange ? :(event :SyntheticInputEvent<HTMLInputElement>) => void;
-  onFocus ? :(event :SyntheticFocusEvent<HTMLInputElement>) => void;
-  readOnly ? :boolean;
-  value ? :any;
-|}
+  checked ?:boolean;
+  defaultChecked ?:boolean;
+  disabled ?:boolean;
+  forwardedRef ?:any;
+  id ?:string;
+  label ?:string;
+  mode ?:string;
+  name ?:string;
+  onBlur ?:(event :SyntheticFocusEvent<HTMLInputElement>) => void;
+  onChange ?:(event :SyntheticInputEvent<HTMLInputElement>) => void;
+  onFocus ?:(event :SyntheticFocusEvent<HTMLInputElement>) => void;
+  readOnly ?:boolean;
+  value ?:any;
+|};
 
 /* eslint-disable react/jsx-props-no-spreading */
 const Checkbox = ({
   disabled,
+  forwardedRef,
   id,
   label,
   mode,
@@ -41,9 +43,8 @@ const Checkbox = ({
             id={id}
             readOnly={readOnly}
             disabled={disabled || readOnly}
-            // $FlowFixMe
-            {...rest} />
-        <CheckboxIndicator mode={mode}>
+            {...rest}
+            ref={forwardedRef} />
           { mode === 'button' && label }
         </CheckboxIndicator>
       </ChoiceInnerWrapper>
@@ -63,6 +64,7 @@ Checkbox.defaultProps = {
   checked: undefined,
   defaultChecked: undefined,
   disabled: false,
+  forwardedRef: undefined,
   id: undefined,
   label: undefined,
   mode: undefined,
@@ -74,4 +76,8 @@ Checkbox.defaultProps = {
   value: undefined,
 };
 
-export default Checkbox;
+export default React.forwardRef<Props, HTMLInputElement>((props, ref) => (
+  /* eslint-disable react/jsx-props-no-spreading */
+  <Checkbox {...props} forwardedRef={ref} />
+  /* eslint-enable */
+));

--- a/src/choices/src/components/__snapshots__/Checkbox.test.js.snap
+++ b/src/choices/src/components/__snapshots__/Checkbox.test.js.snap
@@ -138,220 +138,227 @@ input:checked ~ .c4:after {
   flex: 1;
 }
 
-<Checkbox
-  disabled={false}
->
-  <ChoiceLabel
+<ForwardRef>
+  <Checkbox
     disabled={false}
+    forwardedRef={null}
   >
-    <StyledComponent
+    <ChoiceLabel
       disabled={false}
-      forwardedComponent={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "attrs": Array [],
-          "componentStyle": ComponentStyle {
-            "componentId": "ChoiceLabel-sc-11kob9e-0",
-            "isStatic": false,
-            "lastClassName": "c0",
-            "rules": Array [
-              "align-items:center;color:",
-              [Function],
-              ";display:inline-flex;font-size:14px;min-height:40px;pointer-events:",
-              [Function],
-              ";position:relative;vertical-align:middle;",
-            ],
-          },
-          "displayName": "ChoiceLabel",
-          "foldedComponentIds": Array [],
-          "render": [Function],
-          "styledComponentId": "ChoiceLabel-sc-11kob9e-0",
-          "target": "label",
-          "toString": [Function],
-          "warnTooManyClasses": [Function],
-          "withComponent": [Function],
-        }
-      }
-      forwardedRef={null}
     >
-      <label
-        className="c0"
+      <StyledComponent
         disabled={false}
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "ChoiceLabel-sc-11kob9e-0",
+              "isStatic": false,
+              "lastClassName": "c0",
+              "rules": Array [
+                "align-items:center;color:",
+                [Function],
+                ";display:inline-flex;font-size:14px;min-height:40px;pointer-events:",
+                [Function],
+                ";position:relative;vertical-align:middle;",
+              ],
+            },
+            "displayName": "ChoiceLabel",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "ChoiceLabel-sc-11kob9e-0",
+            "target": "label",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
       >
-        <ChoiceWrappers__ChoiceWrapper>
-          <StyledComponent
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "ChoiceWrappers__ChoiceWrapper-kj63qq-0",
-                  "isStatic": false,
-                  "lastClassName": "c1",
-                  "rules": Array [
-                    "align-items:stretch;display:inline-flex;justify-content:center;position:relative;vertical-align:middle;",
-                    [Function],
-                    ";",
-                  ],
-                },
-                "displayName": "ChoiceWrappers__ChoiceWrapper",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "ChoiceWrappers__ChoiceWrapper-kj63qq-0",
-                "target": "span",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
+        <label
+          className="c0"
+          disabled={false}
+        >
+          <ChoiceWrappers__ChoiceWrapper>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "ChoiceWrappers__ChoiceWrapper-kj63qq-0",
+                    "isStatic": false,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "align-items:stretch;display:inline-flex;justify-content:center;position:relative;vertical-align:middle;",
+                      [Function],
+                      ";",
+                    ],
+                  },
+                  "displayName": "ChoiceWrappers__ChoiceWrapper",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "ChoiceWrappers__ChoiceWrapper-kj63qq-0",
+                  "target": "span",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
               }
-            }
-            forwardedRef={null}
-          >
-            <span
-              className="c1"
+              forwardedRef={null}
             >
-              <ChoiceWrappers__ChoiceInnerWrapper>
-                <StyledComponent
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "ChoiceWrappers__ChoiceInnerWrapper-kj63qq-1",
-                        "isStatic": false,
-                        "lastClassName": "c2",
-                        "rules": Array [
-                          "display:flex;flex:1;",
-                        ],
-                      },
-                      "displayName": "ChoiceWrappers__ChoiceInnerWrapper",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "ChoiceWrappers__ChoiceInnerWrapper-kj63qq-1",
-                      "target": "span",
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
+              <span
+                className="c1"
+              >
+                <ChoiceWrappers__ChoiceInnerWrapper>
+                  <StyledComponent
+                    forwardedComponent={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "ChoiceWrappers__ChoiceInnerWrapper-kj63qq-1",
+                          "isStatic": false,
+                          "lastClassName": "c2",
+                          "rules": Array [
+                            "display:flex;flex:1;",
+                          ],
+                        },
+                        "displayName": "ChoiceWrappers__ChoiceInnerWrapper",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "ChoiceWrappers__ChoiceInnerWrapper-kj63qq-1",
+                        "target": "span",
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
+                      }
                     }
-                  }
-                  forwardedRef={null}
-                >
-                  <span
-                    className="c2"
+                    forwardedRef={null}
                   >
-                    <ChoiceInputs__CheckboxInput>
-                      <StyledComponent
-                        forwardedComponent={
-                          Object {
-                            "$$typeof": Symbol(react.forward_ref),
-                            "attrs": Array [
-                              [Function],
-                            ],
-                            "componentStyle": ComponentStyle {
-                              "componentId": "ChoiceInputs__CheckboxInput-sc-1fkg6yx-1",
-                              "isStatic": false,
-                              "lastClassName": "c3",
-                              "rules": Array [
-                                "height:100%;left:0;margin:0;opacity:0;position:absolute;top:0;vertical-align:middle;width:100%;z-index:-1;",
-                                ";",
-                              ],
-                            },
-                            "displayName": "ChoiceInputs__CheckboxInput",
-                            "foldedComponentIds": Array [],
-                            "render": [Function],
-                            "styledComponentId": "ChoiceInputs__CheckboxInput-sc-1fkg6yx-1",
-                            "target": "input",
-                            "toString": [Function],
-                            "warnTooManyClasses": [Function],
-                            "withComponent": [Function],
-                          }
-                        }
-                        forwardedRef={null}
-                      >
-                        <input
-                          className="c3"
-                          type="checkbox"
-                        />
-                      </StyledComponent>
-                    </ChoiceInputs__CheckboxInput>
-                    <CheckboxIndicator>
-                      <StyledComponent
-                        forwardedComponent={
-                          Object {
-                            "$$typeof": Symbol(react.forward_ref),
-                            "attrs": Array [],
-                            "componentStyle": ComponentStyle {
-                              "componentId": "CheckboxIndicator-sc-16t4mhx-0",
-                              "isStatic": false,
-                              "lastClassName": "c4",
-                              "rules": Array [
-                                "transition:background-color ",
-                                "100ms",
-                                " ease-out,border-color ",
-                                "100ms",
-                                " ease-out,box-shadow ",
-                                "100ms",
-                                " ease-out,color ",
-                                "100ms",
-                                " ease-out;",
+                    <span
+                      className="c2"
+                    >
+                      <ChoiceInputs__CheckboxInput>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [
                                 [Function],
                               ],
-                            },
-                            "displayName": "CheckboxIndicator",
-                            "foldedComponentIds": Array [],
-                            "render": [Function],
-                            "styledComponentId": "CheckboxIndicator-sc-16t4mhx-0",
-                            "target": "span",
-                            "toString": [Function],
-                            "warnTooManyClasses": [Function],
-                            "withComponent": [Function],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "ChoiceInputs__CheckboxInput-sc-1fkg6yx-1",
+                                "isStatic": false,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "height:100%;left:0;margin:0;opacity:0;position:absolute;top:0;vertical-align:middle;width:100%;z-index:-1;",
+                                  ";",
+                                ],
+                              },
+                              "displayName": "ChoiceInputs__CheckboxInput",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "ChoiceInputs__CheckboxInput-sc-1fkg6yx-1",
+                              "target": "input",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
                           }
-                        }
-                        forwardedRef={null}
+                          forwardedRef={null}
+                        >
+                          <input
+                            className="c3"
+                            type="checkbox"
+                          />
+                        </StyledComponent>
+                      </ChoiceInputs__CheckboxInput>
+                      <CheckboxIndicator
+                        onClick={[Function]}
                       >
-                        <span
-                          className="c4"
-                        />
-                      </StyledComponent>
-                    </CheckboxIndicator>
-                  </span>
-                </StyledComponent>
-              </ChoiceWrappers__ChoiceInnerWrapper>
-            </span>
-          </StyledComponent>
-        </ChoiceWrappers__ChoiceWrapper>
-        <ChoiceText>
-          <StyledComponent
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "ChoiceText-sc-1qnriny-0",
-                  "isStatic": false,
-                  "lastClassName": "c5",
-                  "rules": Array [
-                    "margin-left:10px;",
-                  ],
-                },
-                "displayName": "ChoiceText",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "ChoiceText-sc-1qnriny-0",
-                "target": "span",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "CheckboxIndicator-sc-16t4mhx-0",
+                                "isStatic": false,
+                                "lastClassName": "c4",
+                                "rules": Array [
+                                  "transition:background-color ",
+                                  "100ms",
+                                  " ease-out,border-color ",
+                                  "100ms",
+                                  " ease-out,box-shadow ",
+                                  "100ms",
+                                  " ease-out,color ",
+                                  "100ms",
+                                  " ease-out;",
+                                  [Function],
+                                ],
+                              },
+                              "displayName": "CheckboxIndicator",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "CheckboxIndicator-sc-16t4mhx-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          onClick={[Function]}
+                        >
+                          <span
+                            className="c4"
+                            onClick={[Function]}
+                          />
+                        </StyledComponent>
+                      </CheckboxIndicator>
+                    </span>
+                  </StyledComponent>
+                </ChoiceWrappers__ChoiceInnerWrapper>
+              </span>
+            </StyledComponent>
+          </ChoiceWrappers__ChoiceWrapper>
+          <ChoiceText>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "ChoiceText-sc-1qnriny-0",
+                    "isStatic": false,
+                    "lastClassName": "c5",
+                    "rules": Array [
+                      "margin-left:10px;",
+                    ],
+                  },
+                  "displayName": "ChoiceText",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "ChoiceText-sc-1qnriny-0",
+                  "target": "span",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
               }
-            }
-            forwardedRef={null}
-          >
-            <span
-              className="c5"
-            />
-          </StyledComponent>
-        </ChoiceText>
-      </label>
-    </StyledComponent>
-  </ChoiceLabel>
-</Checkbox>
+              forwardedRef={null}
+            >
+              <span
+                className="c5"
+              />
+            </StyledComponent>
+          </ChoiceText>
+        </label>
+      </StyledComponent>
+    </ChoiceLabel>
+  </Checkbox>
+</ForwardRef>
 `;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,5 @@
+/*
+ * @flow
+ */
+
+export { default as stopPropagation } from './stopPropagation';

--- a/src/utils/stopPropagation.js
+++ b/src/utils/stopPropagation.js
@@ -1,0 +1,9 @@
+/*
+ * @flow
+ */
+
+const stopPropagation = (event :SyntheticEvent<HTMLElement>) => {
+  event.stopPropagation();
+};
+
+export default stopPropagation;

--- a/src/utils/stopPropagation.js
+++ b/src/utils/stopPropagation.js
@@ -2,8 +2,12 @@
  * @flow
  */
 
+import _isFunction from 'lodash/isFunction';
+
 const stopPropagation = (event :SyntheticEvent<HTMLElement>) => {
-  event.stopPropagation();
+  if (event && _isFunction(event.stopPropagation)) {
+    event.stopPropagation();
+  }
 };
 
 export default stopPropagation;

--- a/src/utils/stopPropagation.test.js
+++ b/src/utils/stopPropagation.test.js
@@ -1,0 +1,23 @@
+/*
+ * @flow
+ */
+
+import stopPropagation from './stopPropagation';
+import { INVALID_PARAMS } from './testing/InvalidParams';
+
+describe('stopPropagation', () => {
+
+  test('should not throw when given valid parameters', () => {
+    const errors = [];
+    INVALID_PARAMS.forEach((invalidParam) => {
+      try {
+        stopPropagation(invalidParam);
+      }
+      catch (e) {
+        errors.push(`expected not to throw - stopPropagation(${JSON.stringify(invalidParam)})`);
+      }
+    });
+    expect(errors).toEqual([]);
+  });
+
+});

--- a/src/utils/stopPropagation.test.js
+++ b/src/utils/stopPropagation.test.js
@@ -7,7 +7,14 @@ import { INVALID_PARAMS } from './testing/InvalidParams';
 
 describe('stopPropagation', () => {
 
-  test('should not throw when given valid parameters', () => {
+  test('should invoke stopPropagation()', () => {
+    const mockFn = jest.fn();
+    // $FlowFixMe
+    stopPropagation({ stopPropagation: mockFn });
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not throw when given invalid parameters', () => {
     const errors = [];
     INVALID_PARAMS.forEach((invalidParam) => {
       try {

--- a/src/utils/testing/InvalidParams.js
+++ b/src/utils/testing/InvalidParams.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-array-constructor, no-new-object, no-new-wrappers, no-multi-spaces */
+const INVALID_PARAMS = [
+  undefined,                      // 0
+  null,                           // 1
+  [],                             // 2
+  new Array(),                    // 3
+  {},                             // 4
+  new Object(),                   // 5
+  true,                           // 6
+  false,                          // 7
+  new Boolean(true),              // 8
+  new Boolean(false),             // 9
+  -1,                             // 10
+  0,                              // 11
+  1,                              // 12
+  '',                             // 13
+  ' ',                            // 14
+  new String(),                   // 15
+  'invalid_special_string_value', // 16
+  /regex/,                        // 17
+];
+/* eslint-enable */
+
+export {
+  INVALID_PARAMS,
+};


### PR DESCRIPTION
This PR addresses the following bug:

```
<Card onClick={handleOnClick}>
  <CardSegment>
    <Checkbox onChange={onChange} />
  </CardSegment>
</Card>
```

In this scenario, clicking on the checkbox actually ends up invoking the `Card` click handler, which makes sense. In order to prevent `Card`'s click handler from being triggered, we need to `stopPropagation` in the `Checkbox`'s `onChange` callback AND we also need pass a `ref` to `Checkbox`. Then, in the `Card`'s click handler, we check targets:

```
const onChange = (event :SyntheticEvent<HTMLInputElement>) => {
  event.stopPropagation();
  ...
};
const handleOnClick = (event :SyntheticEvent<HTMLElement>) => {
  if (event.target === checkboxRef.current) {
    return;
  }
  ... 
};
```

However, due to the `Checkbox` layout, clicking on the checkbox input also results in clicking on `CheckboxIndicator`, which means there are 2 events that bubble up to `Card`. So, `event.target === checkboxRef.current` will only be true for the event for `Checkbox`, but not for the event for `CheckboxIndicator`. To address this, I added the `onClick={stopPropagation}` bit to `CheckboxIndicator`, which prevents the event from bubbling up.
