### PR TITLE
AppContentWrapper sizing matches Figma

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,9 +81,11 @@ export {
   Step
 } from './stepper';
 export { Input, SearchInput, TextArea } from './text';
+
+// NOTE: doing this because adding @flow to layout/index.js will break things
+export { default as AppContainerWrapper } from './layout/src/components/App/AppContainerWrapper';
+export { default as AppContentWrapper } from './layout/src/components/App/AppContentWrapper';
 export {
-  AppContainerWrapper,
-  AppContentWrapper,
   AppHeaderWrapper,
   AppNavigationWrapper,
   Card,
@@ -91,6 +93,7 @@ export {
   CardSegment,
   CardStack
 } from './layout';
+
 export { Creatable, Select, CheckboxSelect } from './select';
 export {
   Cell,

--- a/src/layout/src/components/App/AppContentWrapper.js
+++ b/src/layout/src/components/App/AppContentWrapper.js
@@ -8,23 +8,19 @@ import type { Node } from 'react';
 import AppContentInnerWrapper from './styled/AppContentInnerWrapper';
 import AppContentOuterWrapper from './styled/AppContentOuterWrapper';
 
-type Props = {
-  bgColor :?string;
-  borderless :boolean;
-  children :Node;
-  className :?string;
-  padding :?string;
-};
-
 const AppContentWrapper = ({
   bgColor,
   borderless,
   children,
   className,
-  padding,
-} :Props) => (
+} :{|
+  bgColor ?:string;
+  borderless :boolean;
+  children :Node;
+  className ?:string;
+|}) => (
   <AppContentOuterWrapper bgColor={bgColor} borderless={borderless} className={className}>
-    <AppContentInnerWrapper padding={padding}>
+    <AppContentInnerWrapper>
       {children}
     </AppContentInnerWrapper>
   </AppContentOuterWrapper>
@@ -34,7 +30,6 @@ AppContentWrapper.defaultProps = {
   bgColor: undefined,
   borderless: false,
   className: undefined,
-  padding: undefined,
 };
 
 export default AppContentWrapper;

--- a/src/layout/src/components/App/AppContentWrapper.test.js
+++ b/src/layout/src/components/App/AppContentWrapper.test.js
@@ -6,7 +6,6 @@ import { mount, shallow } from 'enzyme';
 import AppContentInnerWrapper from './styled/AppContentInnerWrapper';
 import AppContentOuterWrapper from './styled/AppContentOuterWrapper';
 import AppContentWrapper from './AppContentWrapper';
-import { APP_CONTAINER_MIN_WIDTH, APP_CONTENT_PADDING } from '../../../../style/Sizes';
 
 describe('AppContentWrapper', () => {
 
@@ -111,9 +110,9 @@ describe('AppContentWrapper', () => {
         expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('flex', '1 0 auto');
         expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('flex-direction', 'column');
         expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('justify-content', 'flex-start');
-        expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('max-width', `${APP_CONTAINER_MIN_WIDTH}px`);
+        expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('max-width', '1168px');
         expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('min-width', '0');
-        expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('padding', `${APP_CONTENT_PADDING}px`);
+        expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('padding', '32px');
         expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('position', 'relative');
         expect(wrapper.find(AppContentInnerWrapper)).toHaveStyleRule('width', '100%');
       });

--- a/src/layout/src/components/App/__snapshots__/AppContentWrapper.test.js.snap
+++ b/src/layout/src/components/App/__snapshots__/AppContentWrapper.test.js.snap
@@ -6,21 +6,21 @@ exports[`AppContentWrapper snapshots should match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  max-width: 1020px;
+  max-width: 1168px;
   min-width: 0;
+  padding: 32px;
   position: relative;
   width: 100%;
-  padding: 30px;
 }
 
 .c0 {
@@ -43,7 +43,7 @@ exports[`AppContentWrapper snapshots should match snapshot 1`] = `
 
 @media (max-width:36em) {
   .c1 {
-    padding: 20px;
+    padding: 16px;
   }
 }
 
@@ -94,10 +94,20 @@ exports[`AppContentWrapper snapshots should match snapshot 1`] = `
                   "isStatic": false,
                   "lastClassName": "c1",
                   "rules": Array [
-                    "display:flex;flex:1 0 auto;flex-direction:column;justify-content:flex-start;max-width:",
-                    "1020",
-                    "px;min-width:0;position:relative;width:100%;",
-                    [Function],
+                    "display:flex;flex-direction:column;flex:1 0 auto;justify-content:flex-start;max-width:",
+                    "1168",
+                    "px;min-width:0;padding:",
+                    "32",
+                    "px;position:relative;width:100%;",
+                    "@media (max-width:",
+                    "36",
+                    "em){",
+                    "
+    padding: ",
+                    "16",
+                    "px;
+  ",
+                    "}",
                   ],
                 },
                 "displayName": "AppContentInnerWrapper",

--- a/src/layout/src/components/App/styled/AppContentInnerWrapper.js
+++ b/src/layout/src/components/App/styled/AppContentInnerWrapper.js
@@ -2,40 +2,24 @@
  * @flow
  */
 
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-import { APP_CONTENT_PADDING, APP_CONTENT_WIDTH } from '../../../../../style/Sizes';
+import { APP_CONTENT_WIDTH, APP_CONTENT_PADDING } from '../../../../../style/Sizes';
 import { media } from '../../../../../utils/StyleUtils';
-
-type Props = {
-  padding :?number;
-};
-
-const getComputedStyles = ({ padding } :Props) => {
-
-  let finalPadding = `${APP_CONTENT_PADDING}px`;
-  if (typeof padding === 'string') {
-    finalPadding = padding;
-  }
-
-  return css`
-    padding: ${finalPadding};
-    ${media.phone`
-      padding: ${() => padding || 20}px;
-    `}
-  `;
-};
 
 const AppContentInnerWrapper = styled.div`
   display: flex;
-  flex: 1 0 auto;
   flex-direction: column;
+  flex: 1 0 auto;
   justify-content: flex-start;
-  max-width: ${APP_CONTENT_WIDTH}px;
+  max-width: ${APP_CONTENT_WIDTH + (2 * APP_CONTENT_PADDING)}px;
   min-width: 0;
+  padding: ${APP_CONTENT_PADDING}px;
   position: relative;
   width: 100%;
-  ${getComputedStyles}
+  ${media.phone`
+    padding: ${APP_CONTENT_PADDING / 2}px;
+  `}
 `;
 
 export default AppContentInnerWrapper;

--- a/src/layout/src/components/App/styled/AppContentOuterWrapper.js
+++ b/src/layout/src/components/App/styled/AppContentOuterWrapper.js
@@ -7,8 +7,8 @@ import styled, { css } from 'styled-components';
 import { NEUTRAL } from '../../../../../colors';
 
 type Props = {
-  bgColor :?string;
-  borderless :boolean;
+  bgColor ?:string;
+  borderless ?:boolean;
 };
 
 const getComputedStyles = ({ bgColor, borderless } :Props) => {

--- a/src/style/Sizes.js
+++ b/src/style/Sizes.js
@@ -2,13 +2,10 @@
  * @flow
  */
 
-const APP_CONTENT_PADDING :number = 30;
-const APP_CONTENT_WIDTH :number = 960 + (APP_CONTENT_PADDING * 2);
-
-const APP_CONTAINER_MIN_WIDTH :number = APP_CONTENT_WIDTH; // 1020 = 960 for content + 2*30 for edges padding
+const APP_CONTENT_PADDING :32 = 32;
+const APP_CONTENT_WIDTH :1104 = 1104; // 12 column grid system: 48px * (12 columns + 11 gutters)
 
 export {
-  APP_CONTAINER_MIN_WIDTH,
   APP_CONTENT_PADDING,
   APP_CONTENT_WIDTH,
 };

--- a/src/style/Sizes.test.js
+++ b/src/style/Sizes.test.js
@@ -3,9 +3,8 @@ import { Map } from 'immutable';
 import * as Sizes from './Sizes';
 
 const EXPECTED = Map({
-  APP_CONTAINER_MIN_WIDTH: 1020,
-  APP_CONTENT_PADDING: 30,
-  APP_CONTENT_WIDTH: 1020,
+  APP_CONTENT_PADDING: 32,
+  APP_CONTENT_WIDTH: 1104,
 });
 
 describe('Sizes', () => {


### PR DESCRIPTION
- change app content width and padding constants
- removing padding prop from AppContentWrapper
- flow things

"flow things" allows for this:

<img width="452" alt="Screen Shot 2020-09-09 at 7 29 26 PM" src="https://user-images.githubusercontent.com/440299/92675029-641f1000-f2d3-11ea-8d44-746bac82e9d0.png">
