### PR TITLE
Fix and Update Radio Button Styles

### DIFF
--- a/src/choices/src/components/Radio.js
+++ b/src/choices/src/components/Radio.js
@@ -4,6 +4,7 @@ import {
   ChoiceLabel,
   ChoiceText,
   ChoiceWrapper,
+  RadioButtonIndicator,
   RadioIndicator,
   RadioInput,
 } from './styled';
@@ -40,9 +41,11 @@ const Radio = ({
             disabled={disabled || readOnly}
             // $FlowFixMe
             {...rest} />
-        <RadioIndicator mode={mode}>
-          { mode === 'button' && label }
-        </RadioIndicator>
+        {
+          (mode === 'button' && label)
+            ? <RadioButtonIndicator>{label}</RadioButtonIndicator>
+            : <RadioIndicator />
+        }
       </ChoiceInnerWrapper>
     </ChoiceWrapper>
     {

--- a/src/choices/src/components/Radio.test.js
+++ b/src/choices/src/components/Radio.test.js
@@ -2,9 +2,12 @@ import toJson from 'enzyme-to-json';
 import { mount } from 'enzyme';
 
 import Radio from './Radio';
-import choiceButtonStyles from './styled/ChoiceButtonStyles';
-import { ChoiceLabel, RadioIndicator, RadioInput } from './styled';
-import { getIndicatorStyles } from './styled/RadioIndicator';
+import {
+  ChoiceLabel,
+  RadioButtonIndicator,
+  RadioIndicator,
+  RadioInput
+} from './styled';
 
 describe('Radio', () => {
 
@@ -66,14 +69,9 @@ describe('Radio', () => {
 
   describe('mode', () => {
 
-    test('should pass mode to RadioIndicator', () => {
-      const wrapper = mount(<Radio mode="button" />);
-      expect(wrapper.find(RadioIndicator).prop('mode')).toEqual('button');
-    });
-
-    test('mode="button" should use choiceButtonStyles', () => {
-      const indicatorStyles = getIndicatorStyles({ mode: 'button' });
-      expect(indicatorStyles).toEqual(choiceButtonStyles);
+    test('should render RadioButtonIndicator when passed a label and mode="button"', () => {
+      const wrapper = mount(<Radio label="Radio Button" mode="button" />);
+      expect(wrapper.find(RadioButtonIndicator).exists()).toBe(true);
     });
   });
 

--- a/src/choices/src/components/styled/ChoiceButtonStyles.js
+++ b/src/choices/src/components/styled/ChoiceButtonStyles.js
@@ -10,7 +10,7 @@ const choiceButtonStyles = css`
   background-color: ${NEUTRAL.N50};
   border: 3px solid transparent;
   background-clip: padding-box;
-  border-radius: 6px;
+  border-radius: 5px;
   color: ${NEUTRAL.N900};
   display: flex;
   font-size: 1rem;
@@ -23,24 +23,30 @@ const choiceButtonStyles = css`
   user-select: none;
   width: 100%;
 
-  input:focus-visible ~ &,
+  input:focus ~ & {
+    box-shadow: ${NEUTRAL.N400} 0 0 0 1px;
+    cursor: pointer;
+  }
   input:hover ~ & {
-    background-color: ${NEUTRAL.N100};
+    background-color: ${NEUTRAL.N500};
     cursor: pointer;
   }
 
   input:checked ~ &,
-  input[readonly]:checked:disabled ~ &,
-  input[readonly]:checked:hover ~ & {
+  input[readonly]:checked:disabled ~ & {
     background-color: ${PURPLE.P00};
     color: ${PURPLE.P300};
   }
-
-  input:focus-visible ~ & {
-    box-shadow: ${NEUTRAL.N400} 0 0 0 0.1px;
+  input[readonly]:checked:hover ~ & {
+    background-color: ${PURPLE.P100};
   }
-  input:checked:focus-visible ~ & {
-    box-shadow: ${PURPLE.P300} 0 0 0 0.1px;
+
+  input:checked:focus ~ & {
+    box-shadow: ${PURPLE.P300} 0 0 0 1px;
+  }
+
+  input:checked:hover ~ & {
+    background-color: ${PURPLE.P100};
   }
 
   input:disabled ~ & {

--- a/src/choices/src/components/styled/ChoiceButtonStyles.js
+++ b/src/choices/src/components/styled/ChoiceButtonStyles.js
@@ -28,7 +28,7 @@ const choiceButtonStyles = css`
     cursor: pointer;
   }
   input:hover ~ & {
-    background-color: ${NEUTRAL.N500};
+    background-color: ${NEUTRAL.N100};
     cursor: pointer;
   }
 

--- a/src/choices/src/components/styled/RadioButtonIndicator.js
+++ b/src/choices/src/components/styled/RadioButtonIndicator.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+import choiceButtonStyles from './ChoiceButtonStyles';
+
+import { duration } from '../../../../style/transitions';
+
+const RadioButtonIndicator = styled.span`
+  transition: background-color ${duration.swift} ease-out,
+    border-color ${duration.swift} ease-out,
+    box-shadow ${duration.swift} ease-out,
+    color ${duration.swift} ease-out;
+
+  ${choiceButtonStyles};
+`;
+
+export default RadioButtonIndicator;

--- a/src/choices/src/components/styled/RadioIndicator.js
+++ b/src/choices/src/components/styled/RadioIndicator.js
@@ -1,11 +1,9 @@
 import styled, { css } from 'styled-components';
 
-import choiceButtonStyles from './ChoiceButtonStyles';
 import choiceIndicatorStyles from './ChoiceIndicatorStyles';
 
 import { NEUTRAL } from '../../../../colors';
 import { duration } from '../../../../style/transitions';
-import { getStyleVariation } from '../../../../utils/StyleUtils';
 
 const afterStyles = css`
   content: '';
@@ -47,20 +45,13 @@ const radioWithAfterStyles = css`
   }
 `;
 
-const getIndicatorStyles = getStyleVariation('mode', {
-  button: choiceButtonStyles
-}, radioWithAfterStyles);
-
 const RadioIndicator = styled.span`
   transition: background-color ${duration.swift} ease-out,
     border-color ${duration.swift} ease-out,
     box-shadow ${duration.swift} ease-out,
     color ${duration.swift} ease-out;
 
-  ${getIndicatorStyles};
+  ${radioWithAfterStyles};
 `;
 
 export default RadioIndicator;
-export {
-  getIndicatorStyles
-};

--- a/src/choices/src/components/styled/index.js
+++ b/src/choices/src/components/styled/index.js
@@ -3,6 +3,7 @@ import ChoiceGroup from './ChoiceGroup';
 import ChoiceLabel from './ChoiceLabel';
 import ChoiceText from './ChoiceText';
 import RadioIndicator from './RadioIndicator';
+import RadioButtonIndicator from './RadioButtonIndicator';
 import { CheckboxInput, RadioInput } from './ChoiceInputs';
 import { ChoiceInnerWrapper, ChoiceWrapper } from './ChoiceWrappers';
 
@@ -14,6 +15,7 @@ export {
   ChoiceLabel,
   ChoiceText,
   ChoiceWrapper,
+  RadioButtonIndicator,
   RadioIndicator,
   RadioInput,
 };


### PR DESCRIPTION
There was an issue where styles were bing merged for regular and button mode of the Radio during the build. The only way I could figure this out was to separate the `RadioIndicator` and `RadioButtonIndicator` into two separate files.

I also updated button styles to match current designs.

![radio_button](https://user-images.githubusercontent.com/19995069/114090876-d6a59d80-986c-11eb-855f-5d9ebb016cc3.gif)
![checkbox_button](https://user-images.githubusercontent.com/19995069/114090884-d9a08e00-986c-11eb-89e9-0df1773635b2.gif)
