### PR TITLE
bugfix/APPS-3160 — fix drawer scrolling

### DIFF
--- a/src/drawer/src/components/__snapshots__/Drawer.test.js.snap
+++ b/src/drawer/src/components/__snapshots__/Drawer.test.js.snap
@@ -283,45 +283,25 @@ exports[`Drawer snapshots isOpen = true 1`] = `
               </div>
             }
           >
-            <LockToggle
-              accountForScrollbars={true}
-              isActive={true}
-            >
-              <SheetProvider
-                accountForScrollbars={true}
-                isActive={true}
+            <TouchScrollable>
+              <OverlayOuterContainer
+                transparent={false}
               >
-                <TouchProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+                <div
+                  className="c0"
                 >
-                  <ScrollLock
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <OverlayInnerContainer
+                    isScrollable={true}
+                    onClick={[Function]}
                   >
-                    <TouchScrollable>
-                      <OverlayOuterContainer
-                        transparent={false}
-                      >
-                        <div
-                          className="c0"
-                        >
-                          <OverlayInnerContainer
-                            isScrollable={true}
-                            onClick={[Function]}
-                          >
-                            <div
-                              className="c1"
-                              onClick={[Function]}
-                            />
-                          </OverlayInnerContainer>
-                        </div>
-                      </OverlayOuterContainer>
-                    </TouchScrollable>
-                  </ScrollLock>
-                </TouchProvider>
-              </SheetProvider>
-            </LockToggle>
+                    <div
+                      className="c1"
+                      onClick={[Function]}
+                    />
+                  </OverlayInnerContainer>
+                </div>
+              </OverlayOuterContainer>
+            </TouchScrollable>
           </Portal>
         </Portal>
       </Transition>

--- a/src/modal/src/components/__snapshots__/ActionModal.test.js.snap
+++ b/src/modal/src/components/__snapshots__/ActionModal.test.js.snap
@@ -579,307 +579,287 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Failure. Please try again.
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={false}
+                                  isPendingPrimary={false}
+                                  isPendingSecondary={false}
+                                  onClickPrimary={[Function]}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Close"
+                                  textSecondary=""
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={false}
+                                        isLoading={false}
+                                        onClick={[Function]}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={false}
+                                          isLoading={false}
+                                          onClick={[Function]}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={false}
+                                            forwardRef={null}
+                                            isLoading={false}
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={false}
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Failure. Please try again.
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={false}
-                                          isPendingPrimary={false}
-                                          isPendingSecondary={false}
-                                          onClickPrimary={[Function]}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Close"
-                                          textSecondary=""
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={false}
-                                                isLoading={false}
-                                                onClick={[Function]}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={false}
-                                                  isLoading={false}
-                                                  onClick={[Function]}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
-                                                    isLoading={false}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
                                                       disabled={false}
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                              disabled={false}
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                Close
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        Close
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>
@@ -1417,307 +1397,287 @@ exports[`ActionModal snapshots should match snapshot when requestState="FAILURE"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Action failed. Please try again.
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={false}
+                                  isPendingPrimary={false}
+                                  isPendingSecondary={false}
+                                  onClickPrimary={[Function]}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Close"
+                                  textSecondary=""
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={false}
+                                        isLoading={false}
+                                        onClick={[Function]}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={false}
+                                          isLoading={false}
+                                          onClick={[Function]}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={false}
+                                            forwardRef={null}
+                                            isLoading={false}
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={false}
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Action failed. Please try again.
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={false}
-                                          isPendingPrimary={false}
-                                          isPendingSecondary={false}
-                                          onClickPrimary={[Function]}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Close"
-                                          textSecondary=""
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={false}
-                                                isLoading={false}
-                                                onClick={[Function]}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={false}
-                                                  isLoading={false}
-                                                  onClick={[Function]}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
-                                                    isLoading={false}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
                                                       disabled={false}
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                              disabled={false}
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                Close
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        Close
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>
@@ -2315,575 +2275,555 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Are you sure?
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={true}
+                                  isPendingPrimary={true}
+                                  isPendingSecondary={false}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Yes, confirm"
+                                  textSecondary="No, cancel"
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={true}
+                                        isLoading={true}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={true}
+                                          isLoading={true}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={true}
+                                            forwardRef={null}
+                                            isLoading={true}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={true}
+                                              startIcon={
+                                                <Spinner
+                                                  bottomColor="#c3c3c8"
+                                                  centered={true}
+                                                  size="1x"
+                                                  topColor="#56565a"
+                                                />
+                                              }
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
-                                                onClick={[Function]}
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={true}
+                                                startIcon={
+                                                  <Spinner
+                                                    bottomColor="#c3c3c8"
+                                                    centered={true}
+                                                    size="1x"
+                                                    topColor="#56565a"
+                                                  />
+                                                }
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
-                                                  onClick={[Function]}
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={true}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Are you sure?
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={true}
-                                          isPendingPrimary={true}
-                                          isPendingSecondary={false}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Yes, confirm"
-                                          textSecondary="No, cancel"
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={true}
-                                                isLoading={true}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={true}
-                                                  isLoading={true}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={true}
-                                                    forwardRef={null}
-                                                    isLoading={true}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled Mui-disabled"
                                                       disabled={true}
-                                                      startIcon={
-                                                        <Spinner
-                                                          bottomColor="#c3c3c8"
-                                                          centered={true}
-                                                          size="1x"
-                                                          topColor="#56565a"
-                                                        />
-                                                      }
-                                                      variant="contained"
+                                                      onBlur={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={-1}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={true}
-                                                        startIcon={
+                                                      <span
+                                                        className="MuiButton-label"
+                                                      >
+                                                        <span
+                                                          className="MuiButton-startIcon MuiButton-iconSizeMedium"
+                                                        >
                                                           <Spinner
                                                             bottomColor="#c3c3c8"
                                                             centered={true}
                                                             size="1x"
                                                             topColor="#56565a"
-                                                          />
-                                                        }
-                                                        variant="contained"
-                                                      >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={true}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={true}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            type="button"
                                                           >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled Mui-disabled"
-                                                              disabled={true}
-                                                              onBlur={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={-1}
-                                                              type="button"
+                                                            <styled.span
+                                                              centered={true}
+                                                              className="fa-layers fa-fw fa-1x"
                                                             >
                                                               <span
-                                                                className="MuiButton-label"
+                                                                className="c10 fa-layers fa-fw fa-1x"
                                                               >
-                                                                <span
-                                                                  className="MuiButton-startIcon MuiButton-iconSizeMedium"
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className=""
+                                                                  color="#c3c3c8"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f111",
+                                                                        "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z",
+                                                                      ],
+                                                                      "iconName": "circle",
+                                                                      "prefix": "fal",
+                                                                    }
+                                                                  }
+                                                                  id="spinner-circle"
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size={null}
+                                                                  spin={false}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
                                                                 >
-                                                                  <Spinner
-                                                                    bottomColor="#c3c3c8"
-                                                                    centered={true}
-                                                                    size="1x"
-                                                                    topColor="#56565a"
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-circle fa-w-16 "
+                                                                    color="#c3c3c8"
+                                                                    data-icon="circle"
+                                                                    data-prefix="fal"
+                                                                    focusable="false"
+                                                                    id="spinner-circle"
+                                                                    role="img"
+                                                                    style={Object {}}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <styled.span
-                                                                      centered={true}
-                                                                      className="fa-layers fa-fw fa-1x"
-                                                                    >
-                                                                      <span
-                                                                        className="c10 fa-layers fa-fw fa-1x"
-                                                                      >
-                                                                        <FontAwesomeIcon
-                                                                          border={false}
-                                                                          className=""
-                                                                          color="#c3c3c8"
-                                                                          fixedWidth={false}
-                                                                          flip={null}
-                                                                          icon={
-                                                                            Object {
-                                                                              "icon": Array [
-                                                                                512,
-                                                                                512,
-                                                                                Array [],
-                                                                                "f111",
-                                                                                "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z",
-                                                                              ],
-                                                                              "iconName": "circle",
-                                                                              "prefix": "fal",
-                                                                            }
-                                                                          }
-                                                                          id="spinner-circle"
-                                                                          inverse={false}
-                                                                          listItem={false}
-                                                                          mask={null}
-                                                                          pull={null}
-                                                                          pulse={false}
-                                                                          rotation={null}
-                                                                          size={null}
-                                                                          spin={false}
-                                                                          swapOpacity={false}
-                                                                          symbol={false}
-                                                                          title=""
-                                                                          transform={null}
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden="true"
-                                                                            className="svg-inline--fa fa-circle fa-w-16 "
-                                                                            color="#c3c3c8"
-                                                                            data-icon="circle"
-                                                                            data-prefix="fal"
-                                                                            focusable="false"
-                                                                            id="spinner-circle"
-                                                                            role="img"
-                                                                            style={Object {}}
-                                                                            viewBox="0 0 512 512"
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z"
-                                                                              fill="currentColor"
-                                                                              style={Object {}}
-                                                                            />
-                                                                          </svg>
-                                                                        </FontAwesomeIcon>
-                                                                        <FontAwesomeIcon
-                                                                          border={false}
-                                                                          className=""
-                                                                          color="#56565a"
-                                                                          fixedWidth={false}
-                                                                          flip={null}
-                                                                          icon={
-                                                                            Object {
-                                                                              "icon": Array [
-                                                                                512,
-                                                                                512,
-                                                                                Array [],
-                                                                                "f3f4",
-                                                                                "M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z",
-                                                                              ],
-                                                                              "iconName": "spinner-third",
-                                                                              "prefix": "fal",
-                                                                            }
-                                                                          }
-                                                                          id="spinner-third"
-                                                                          inverse={false}
-                                                                          listItem={false}
-                                                                          mask={null}
-                                                                          pull={null}
-                                                                          pulse={false}
-                                                                          rotation={null}
-                                                                          size={null}
-                                                                          spin={false}
-                                                                          swapOpacity={false}
-                                                                          symbol={false}
-                                                                          title=""
-                                                                          transform={null}
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden="true"
-                                                                            className="svg-inline--fa fa-spinner-third fa-w-16 "
-                                                                            color="#56565a"
-                                                                            data-icon="spinner-third"
-                                                                            data-prefix="fal"
-                                                                            focusable="false"
-                                                                            id="spinner-third"
-                                                                            role="img"
-                                                                            style={Object {}}
-                                                                            viewBox="0 0 512 512"
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z"
-                                                                              fill="currentColor"
-                                                                              style={Object {}}
-                                                                            />
-                                                                          </svg>
-                                                                        </FontAwesomeIcon>
-                                                                      </span>
-                                                                    </styled.span>
-                                                                  </Spinner>
-                                                                </span>
-                                                                Yes, confirm
+                                                                    <path
+                                                                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z"
+                                                                      fill="currentColor"
+                                                                      style={Object {}}
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className=""
+                                                                  color="#56565a"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f3f4",
+                                                                        "M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z",
+                                                                      ],
+                                                                      "iconName": "spinner-third",
+                                                                      "prefix": "fal",
+                                                                    }
+                                                                  }
+                                                                  id="spinner-third"
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size={null}
+                                                                  spin={false}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-spinner-third fa-w-16 "
+                                                                    color="#56565a"
+                                                                    data-icon="spinner-third"
+                                                                    data-prefix="fal"
+                                                                    focusable="false"
+                                                                    id="spinner-third"
+                                                                    role="img"
+                                                                    style={Object {}}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z"
+                                                                      fill="currentColor"
+                                                                      style={Object {}}
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
                                                               </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                              <Styled(Component)
+                                                            </styled.span>
+                                                          </Spinner>
+                                                        </span>
+                                                        Yes, confirm
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                      <Styled(Component)
+                                        disabled={true}
+                                        id="secondary"
+                                        isLoading={false}
+                                        name="secondary"
+                                      >
+                                        <ForwardRef
+                                          className=""
+                                          disabled={true}
+                                          id="secondary"
+                                          isLoading={false}
+                                          name="secondary"
+                                        >
+                                          <Button
+                                            className=""
+                                            disabled={true}
+                                            forwardRef={null}
+                                            id="secondary"
+                                            isLoading={false}
+                                            name="secondary"
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className=""
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={true}
+                                              id="secondary"
+                                              name="secondary"
+                                              variant="contained"
+                                            >
+                                              <ForwardRef(Button)
+                                                className=""
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
                                                 disabled={true}
                                                 id="secondary"
-                                                isLoading={false}
                                                 name="secondary"
+                                                variant="contained"
                                               >
-                                                <ForwardRef
-                                                  className=""
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained Mui-disabled"
+                                                  component="button"
+                                                  disableRipple={true}
                                                   disabled={true}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   id="secondary"
-                                                  isLoading={false}
                                                   name="secondary"
+                                                  type="button"
                                                 >
-                                                  <Button
-                                                    className=""
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained Mui-disabled"
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={true}
-                                                    forwardRef={null}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     id="secondary"
-                                                    isLoading={false}
                                                     name="secondary"
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className=""
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained Mui-disabled Mui-disabled"
                                                       disabled={true}
                                                       id="secondary"
                                                       name="secondary"
-                                                      variant="contained"
+                                                      onBlur={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={-1}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className=""
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={true}
-                                                        id="secondary"
-                                                        name="secondary"
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained Mui-disabled"
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={true}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          id="secondary"
-                                                          name="secondary"
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained Mui-disabled"
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={true}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            id="secondary"
-                                                            name="secondary"
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained Mui-disabled Mui-disabled"
-                                                              disabled={true}
-                                                              id="secondary"
-                                                              name="secondary"
-                                                              onBlur={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={-1}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                No, cancel
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        No, cancel
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>
@@ -3493,575 +3433,555 @@ exports[`ActionModal snapshots should match snapshot when requestState="PENDING"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Are you absolutely sure you want to take this action?
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={true}
+                                  isPendingPrimary={true}
+                                  isPendingSecondary={false}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Yes, confirm"
+                                  textSecondary="No, cancel"
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={true}
+                                        isLoading={true}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={true}
+                                          isLoading={true}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={true}
+                                            forwardRef={null}
+                                            isLoading={true}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={true}
+                                              startIcon={
+                                                <Spinner
+                                                  bottomColor="#c3c3c8"
+                                                  centered={true}
+                                                  size="1x"
+                                                  topColor="#56565a"
+                                                />
+                                              }
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
-                                                onClick={[Function]}
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={true}
+                                                startIcon={
+                                                  <Spinner
+                                                    bottomColor="#c3c3c8"
+                                                    centered={true}
+                                                    size="1x"
+                                                    topColor="#56565a"
+                                                  />
+                                                }
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
-                                                  onClick={[Function]}
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={true}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Are you absolutely sure you want to take this action?
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={true}
-                                          isPendingPrimary={true}
-                                          isPendingSecondary={false}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Yes, confirm"
-                                          textSecondary="No, cancel"
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={true}
-                                                isLoading={true}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={true}
-                                                  isLoading={true}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={true}
-                                                    forwardRef={null}
-                                                    isLoading={true}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled Mui-disabled"
                                                       disabled={true}
-                                                      startIcon={
-                                                        <Spinner
-                                                          bottomColor="#c3c3c8"
-                                                          centered={true}
-                                                          size="1x"
-                                                          topColor="#56565a"
-                                                        />
-                                                      }
-                                                      variant="contained"
+                                                      onBlur={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={-1}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={true}
-                                                        startIcon={
+                                                      <span
+                                                        className="MuiButton-label"
+                                                      >
+                                                        <span
+                                                          className="MuiButton-startIcon MuiButton-iconSizeMedium"
+                                                        >
                                                           <Spinner
                                                             bottomColor="#c3c3c8"
                                                             centered={true}
                                                             size="1x"
                                                             topColor="#56565a"
-                                                          />
-                                                        }
-                                                        variant="contained"
-                                                      >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={true}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled"
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={true}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            type="button"
                                                           >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 Mui-disabled Mui-disabled"
-                                                              disabled={true}
-                                                              onBlur={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={-1}
-                                                              type="button"
+                                                            <styled.span
+                                                              centered={true}
+                                                              className="fa-layers fa-fw fa-1x"
                                                             >
                                                               <span
-                                                                className="MuiButton-label"
+                                                                className="c10 fa-layers fa-fw fa-1x"
                                                               >
-                                                                <span
-                                                                  className="MuiButton-startIcon MuiButton-iconSizeMedium"
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className=""
+                                                                  color="#c3c3c8"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f111",
+                                                                        "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z",
+                                                                      ],
+                                                                      "iconName": "circle",
+                                                                      "prefix": "fal",
+                                                                    }
+                                                                  }
+                                                                  id="spinner-circle"
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size={null}
+                                                                  spin={false}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
                                                                 >
-                                                                  <Spinner
-                                                                    bottomColor="#c3c3c8"
-                                                                    centered={true}
-                                                                    size="1x"
-                                                                    topColor="#56565a"
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-circle fa-w-16 "
+                                                                    color="#c3c3c8"
+                                                                    data-icon="circle"
+                                                                    data-prefix="fal"
+                                                                    focusable="false"
+                                                                    id="spinner-circle"
+                                                                    role="img"
+                                                                    style={Object {}}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
                                                                   >
-                                                                    <styled.span
-                                                                      centered={true}
-                                                                      className="fa-layers fa-fw fa-1x"
-                                                                    >
-                                                                      <span
-                                                                        className="c10 fa-layers fa-fw fa-1x"
-                                                                      >
-                                                                        <FontAwesomeIcon
-                                                                          border={false}
-                                                                          className=""
-                                                                          color="#c3c3c8"
-                                                                          fixedWidth={false}
-                                                                          flip={null}
-                                                                          icon={
-                                                                            Object {
-                                                                              "icon": Array [
-                                                                                512,
-                                                                                512,
-                                                                                Array [],
-                                                                                "f111",
-                                                                                "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z",
-                                                                              ],
-                                                                              "iconName": "circle",
-                                                                              "prefix": "fal",
-                                                                            }
-                                                                          }
-                                                                          id="spinner-circle"
-                                                                          inverse={false}
-                                                                          listItem={false}
-                                                                          mask={null}
-                                                                          pull={null}
-                                                                          pulse={false}
-                                                                          rotation={null}
-                                                                          size={null}
-                                                                          spin={false}
-                                                                          swapOpacity={false}
-                                                                          symbol={false}
-                                                                          title=""
-                                                                          transform={null}
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden="true"
-                                                                            className="svg-inline--fa fa-circle fa-w-16 "
-                                                                            color="#c3c3c8"
-                                                                            data-icon="circle"
-                                                                            data-prefix="fal"
-                                                                            focusable="false"
-                                                                            id="spinner-circle"
-                                                                            role="img"
-                                                                            style={Object {}}
-                                                                            viewBox="0 0 512 512"
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z"
-                                                                              fill="currentColor"
-                                                                              style={Object {}}
-                                                                            />
-                                                                          </svg>
-                                                                        </FontAwesomeIcon>
-                                                                        <FontAwesomeIcon
-                                                                          border={false}
-                                                                          className=""
-                                                                          color="#56565a"
-                                                                          fixedWidth={false}
-                                                                          flip={null}
-                                                                          icon={
-                                                                            Object {
-                                                                              "icon": Array [
-                                                                                512,
-                                                                                512,
-                                                                                Array [],
-                                                                                "f3f4",
-                                                                                "M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z",
-                                                                              ],
-                                                                              "iconName": "spinner-third",
-                                                                              "prefix": "fal",
-                                                                            }
-                                                                          }
-                                                                          id="spinner-third"
-                                                                          inverse={false}
-                                                                          listItem={false}
-                                                                          mask={null}
-                                                                          pull={null}
-                                                                          pulse={false}
-                                                                          rotation={null}
-                                                                          size={null}
-                                                                          spin={false}
-                                                                          swapOpacity={false}
-                                                                          symbol={false}
-                                                                          title=""
-                                                                          transform={null}
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden="true"
-                                                                            className="svg-inline--fa fa-spinner-third fa-w-16 "
-                                                                            color="#56565a"
-                                                                            data-icon="spinner-third"
-                                                                            data-prefix="fal"
-                                                                            focusable="false"
-                                                                            id="spinner-third"
-                                                                            role="img"
-                                                                            style={Object {}}
-                                                                            viewBox="0 0 512 512"
-                                                                            xmlns="http://www.w3.org/2000/svg"
-                                                                          >
-                                                                            <path
-                                                                              d="M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z"
-                                                                              fill="currentColor"
-                                                                              style={Object {}}
-                                                                            />
-                                                                          </svg>
-                                                                        </FontAwesomeIcon>
-                                                                      </span>
-                                                                    </styled.span>
-                                                                  </Spinner>
-                                                                </span>
-                                                                Yes, confirm
+                                                                    <path
+                                                                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm216 248c0 118.7-96.1 216-216 216-118.7 0-216-96.1-216-216 0-118.7 96.1-216 216-216 118.7 0 216 96.1 216 216z"
+                                                                      fill="currentColor"
+                                                                      style={Object {}}
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
+                                                                <FontAwesomeIcon
+                                                                  border={false}
+                                                                  className=""
+                                                                  color="#56565a"
+                                                                  fixedWidth={false}
+                                                                  flip={null}
+                                                                  icon={
+                                                                    Object {
+                                                                      "icon": Array [
+                                                                        512,
+                                                                        512,
+                                                                        Array [],
+                                                                        "f3f4",
+                                                                        "M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z",
+                                                                      ],
+                                                                      "iconName": "spinner-third",
+                                                                      "prefix": "fal",
+                                                                    }
+                                                                  }
+                                                                  id="spinner-third"
+                                                                  inverse={false}
+                                                                  listItem={false}
+                                                                  mask={null}
+                                                                  pull={null}
+                                                                  pulse={false}
+                                                                  rotation={null}
+                                                                  size={null}
+                                                                  spin={false}
+                                                                  swapOpacity={false}
+                                                                  symbol={false}
+                                                                  title=""
+                                                                  transform={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    className="svg-inline--fa fa-spinner-third fa-w-16 "
+                                                                    color="#56565a"
+                                                                    data-icon="spinner-third"
+                                                                    data-prefix="fal"
+                                                                    focusable="false"
+                                                                    id="spinner-third"
+                                                                    role="img"
+                                                                    style={Object {}}
+                                                                    viewBox="0 0 512 512"
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M460.115 373.846l-6.941-4.008c-5.546-3.202-7.564-10.177-4.661-15.886 32.971-64.838 31.167-142.731-5.415-205.954-36.504-63.356-103.118-103.876-175.8-107.701C260.952 39.963 256 34.676 256 28.321v-8.012c0-6.904 5.808-12.337 12.703-11.982 83.552 4.306 160.157 50.861 202.106 123.67 42.069 72.703 44.083 162.322 6.034 236.838-3.14 6.149-10.75 8.462-16.728 5.011z"
+                                                                      fill="currentColor"
+                                                                      style={Object {}}
+                                                                    />
+                                                                  </svg>
+                                                                </FontAwesomeIcon>
                                                               </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                              <Styled(Component)
+                                                            </styled.span>
+                                                          </Spinner>
+                                                        </span>
+                                                        Yes, confirm
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                      <Styled(Component)
+                                        disabled={true}
+                                        id="secondary"
+                                        isLoading={false}
+                                        name="secondary"
+                                      >
+                                        <ForwardRef
+                                          className=""
+                                          disabled={true}
+                                          id="secondary"
+                                          isLoading={false}
+                                          name="secondary"
+                                        >
+                                          <Button
+                                            className=""
+                                            disabled={true}
+                                            forwardRef={null}
+                                            id="secondary"
+                                            isLoading={false}
+                                            name="secondary"
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className=""
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={true}
+                                              id="secondary"
+                                              name="secondary"
+                                              variant="contained"
+                                            >
+                                              <ForwardRef(Button)
+                                                className=""
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
                                                 disabled={true}
                                                 id="secondary"
-                                                isLoading={false}
                                                 name="secondary"
+                                                variant="contained"
                                               >
-                                                <ForwardRef
-                                                  className=""
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained Mui-disabled"
+                                                  component="button"
+                                                  disableRipple={true}
                                                   disabled={true}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   id="secondary"
-                                                  isLoading={false}
                                                   name="secondary"
+                                                  type="button"
                                                 >
-                                                  <Button
-                                                    className=""
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained Mui-disabled"
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={true}
-                                                    forwardRef={null}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     id="secondary"
-                                                    isLoading={false}
                                                     name="secondary"
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className=""
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained Mui-disabled Mui-disabled"
                                                       disabled={true}
                                                       id="secondary"
                                                       name="secondary"
-                                                      variant="contained"
+                                                      onBlur={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={-1}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className=""
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={true}
-                                                        id="secondary"
-                                                        name="secondary"
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained Mui-disabled"
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={true}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          id="secondary"
-                                                          name="secondary"
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained Mui-disabled"
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={true}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            id="secondary"
-                                                            name="secondary"
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained Mui-disabled Mui-disabled"
-                                                              disabled={true}
-                                                              id="secondary"
-                                                              name="secondary"
-                                                              onBlur={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={-1}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                No, cancel
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        No, cancel
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>
@@ -4588,451 +4508,431 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Are you sure?
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={false}
+                                  isPendingPrimary={false}
+                                  isPendingSecondary={false}
+                                  onClickPrimary={[Function]}
+                                  onClickSecondary={[Function]}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Yes, confirm"
+                                  textSecondary="No, cancel"
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={false}
+                                        isLoading={false}
+                                        onClick={[Function]}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={false}
+                                          isLoading={false}
+                                          onClick={[Function]}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={false}
+                                            forwardRef={null}
+                                            isLoading={false}
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={false}
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Are you sure?
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={false}
-                                          isPendingPrimary={false}
-                                          isPendingSecondary={false}
-                                          onClickPrimary={[Function]}
-                                          onClickSecondary={[Function]}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Yes, confirm"
-                                          textSecondary="No, cancel"
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={false}
-                                                isLoading={false}
-                                                onClick={[Function]}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={false}
-                                                  isLoading={false}
-                                                  onClick={[Function]}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
-                                                    isLoading={false}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
                                                       disabled={false}
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                              disabled={false}
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                Yes, confirm
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                              <Styled(Component)
+                                                        Yes, confirm
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                      <Styled(Component)
+                                        disabled={false}
+                                        id="secondary"
+                                        isLoading={false}
+                                        name="secondary"
+                                        onClick={[Function]}
+                                      >
+                                        <ForwardRef
+                                          className=""
+                                          disabled={false}
+                                          id="secondary"
+                                          isLoading={false}
+                                          name="secondary"
+                                          onClick={[Function]}
+                                        >
+                                          <Button
+                                            className=""
+                                            disabled={false}
+                                            forwardRef={null}
+                                            id="secondary"
+                                            isLoading={false}
+                                            name="secondary"
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className=""
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              id="secondary"
+                                              name="secondary"
+                                              onClick={[Function]}
+                                              variant="contained"
+                                            >
+                                              <ForwardRef(Button)
+                                                className=""
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
                                                 disabled={false}
                                                 id="secondary"
-                                                isLoading={false}
                                                 name="secondary"
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <ForwardRef
-                                                  className=""
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained "
+                                                  component="button"
+                                                  disableRipple={true}
                                                   disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   id="secondary"
-                                                  isLoading={false}
                                                   name="secondary"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <Button
-                                                    className=""
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained "
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     id="secondary"
-                                                    isLoading={false}
                                                     name="secondary"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className=""
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained "
                                                       disabled={false}
                                                       id="secondary"
                                                       name="secondary"
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className=""
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        id="secondary"
-                                                        name="secondary"
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          id="secondary"
-                                                          name="secondary"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            id="secondary"
-                                                            name="secondary"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained "
-                                                              disabled={false}
-                                                              id="secondary"
-                                                              name="secondary"
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                No, cancel
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        No, cancel
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>
@@ -5571,451 +5471,431 @@ exports[`ActionModal snapshots should match snapshot when requestState="STANDBY"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Are you absolutely sure you want to take this action?
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={false}
+                                  isPendingPrimary={false}
+                                  isPendingSecondary={false}
+                                  onClickPrimary={[Function]}
+                                  onClickSecondary={[Function]}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Yes, confirm"
+                                  textSecondary="No, cancel"
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={false}
+                                        isLoading={false}
+                                        onClick={[Function]}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={false}
+                                          isLoading={false}
+                                          onClick={[Function]}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={false}
+                                            forwardRef={null}
+                                            isLoading={false}
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={false}
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Are you absolutely sure you want to take this action?
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={false}
-                                          isPendingPrimary={false}
-                                          isPendingSecondary={false}
-                                          onClickPrimary={[Function]}
-                                          onClickSecondary={[Function]}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Yes, confirm"
-                                          textSecondary="No, cancel"
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={false}
-                                                isLoading={false}
-                                                onClick={[Function]}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={false}
-                                                  isLoading={false}
-                                                  onClick={[Function]}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
-                                                    isLoading={false}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
                                                       disabled={false}
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                              disabled={false}
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                Yes, confirm
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                              <Styled(Component)
+                                                        Yes, confirm
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                      <Styled(Component)
+                                        disabled={false}
+                                        id="secondary"
+                                        isLoading={false}
+                                        name="secondary"
+                                        onClick={[Function]}
+                                      >
+                                        <ForwardRef
+                                          className=""
+                                          disabled={false}
+                                          id="secondary"
+                                          isLoading={false}
+                                          name="secondary"
+                                          onClick={[Function]}
+                                        >
+                                          <Button
+                                            className=""
+                                            disabled={false}
+                                            forwardRef={null}
+                                            id="secondary"
+                                            isLoading={false}
+                                            name="secondary"
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className=""
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              id="secondary"
+                                              name="secondary"
+                                              onClick={[Function]}
+                                              variant="contained"
+                                            >
+                                              <ForwardRef(Button)
+                                                className=""
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
                                                 disabled={false}
                                                 id="secondary"
-                                                isLoading={false}
                                                 name="secondary"
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <ForwardRef
-                                                  className=""
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained "
+                                                  component="button"
+                                                  disableRipple={true}
                                                   disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   id="secondary"
-                                                  isLoading={false}
                                                   name="secondary"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <Button
-                                                    className=""
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained "
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     id="secondary"
-                                                    isLoading={false}
                                                     name="secondary"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className=""
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained "
                                                       disabled={false}
                                                       id="secondary"
                                                       name="secondary"
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className=""
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        id="secondary"
-                                                        name="secondary"
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          id="secondary"
-                                                          name="secondary"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            id="secondary"
-                                                            name="secondary"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained "
-                                                              disabled={false}
-                                                              id="secondary"
-                                                              name="secondary"
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                No, cancel
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        No, cancel
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>
@@ -6541,307 +6421,287 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Success!
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={false}
+                                  isPendingPrimary={false}
+                                  isPendingSecondary={false}
+                                  onClickPrimary={[Function]}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Close"
+                                  textSecondary=""
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={false}
+                                        isLoading={false}
+                                        onClick={[Function]}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={false}
+                                          isLoading={false}
+                                          onClick={[Function]}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={false}
+                                            forwardRef={null}
+                                            isLoading={false}
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={false}
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Success!
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={false}
-                                          isPendingPrimary={false}
-                                          isPendingSecondary={false}
-                                          onClickPrimary={[Function]}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Close"
-                                          textSecondary=""
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={false}
-                                                isLoading={false}
-                                                onClick={[Function]}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={false}
-                                                  isLoading={false}
-                                                  onClick={[Function]}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
-                                                    isLoading={false}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
                                                       disabled={false}
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                              disabled={false}
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                Close
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        Close
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>
@@ -7379,307 +7239,287 @@ exports[`ActionModal snapshots should match snapshot when requestState="SUCCESS"
                 </div>
               }
             >
-              <LockToggle
-                accountForScrollbars={true}
-                isActive={true}
-              >
-                <SheetProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+              <TouchScrollable>
+                <OverlayOuterContainer
+                  transparent={false}
                 >
-                  <TouchProvider
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <div
+                    className="c0"
                   >
-                    <ScrollLock
-                      accountForScrollbars={true}
-                      isActive={true}
+                    <OverlayInnerContainer
+                      isScrollable={false}
+                      onClick={[Function]}
                     >
-                      <TouchScrollable>
-                        <OverlayOuterContainer
-                          transparent={false}
+                      <div
+                        className="c1"
+                        onClick={[Function]}
+                      >
+                        <styled.div
+                          onClick={[Function]}
+                          viewportScrolling={false}
                         >
                           <div
-                            className="c0"
+                            className="c2"
+                            onClick={[Function]}
                           >
-                            <OverlayInnerContainer
-                              isScrollable={false}
-                              onClick={[Function]}
+                            <styled.div
+                              center={true}
+                              viewportScrolling={false}
                             >
                               <div
-                                className="c1"
-                                onClick={[Function]}
+                                className="c3"
                               >
-                                <styled.div
-                                  onClick={[Function]}
+                                <ModalHeader
+                                  onClickClose={[Function]}
+                                  textTitle="Action Action Action"
+                                  withHeader={true}
+                                >
+                                  <Styled(styled.div)>
+                                    <div
+                                      className="c4 c5"
+                                    >
+                                      <styled.h1>
+                                        <h1
+                                          className="c6"
+                                        >
+                                          Action Action Action
+                                        </h1>
+                                      </styled.h1>
+                                      <styled.button
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          className="c7"
+                                          onClick={[Function]}
+                                        >
+                                          <FontAwesomeIcon
+                                            border={false}
+                                            className=""
+                                            fixedWidth={false}
+                                            flip={null}
+                                            icon={
+                                              Object {
+                                                "icon": Array [
+                                                  320,
+                                                  512,
+                                                  Array [],
+                                                  "f00d",
+                                                  "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                                ],
+                                                "iconName": "times",
+                                                "prefix": "fal",
+                                              }
+                                            }
+                                            inverse={false}
+                                            listItem={false}
+                                            mask={null}
+                                            pull={null}
+                                            pulse={false}
+                                            rotation={null}
+                                            size="lg"
+                                            spin={false}
+                                            swapOpacity={false}
+                                            symbol={false}
+                                            title=""
+                                            transform={null}
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                              data-icon="times"
+                                              data-prefix="fal"
+                                              focusable="false"
+                                              role="img"
+                                              style={Object {}}
+                                              viewBox="0 0 320 512"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                                fill="currentColor"
+                                                style={Object {}}
+                                              />
+                                            </svg>
+                                          </FontAwesomeIcon>
+                                        </button>
+                                      </styled.button>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalHeader>
+                                <ModalBody
                                   viewportScrolling={false}
                                 >
-                                  <div
-                                    className="c2"
-                                    onClick={[Function]}
+                                  <Styled(styled.div)
+                                    viewportScrolling={false}
                                   >
-                                    <styled.div
-                                      center={true}
-                                      viewportScrolling={false}
+                                    <div
+                                      className="c4 c8"
                                     >
-                                      <div
-                                        className="c3"
+                                      <span>
+                                        Success! The action has been taken.
+                                      </span>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalBody>
+                                <ModalFooter
+                                  isDisabledPrimary={false}
+                                  isDisabledSecondary={false}
+                                  isPendingPrimary={false}
+                                  isPendingSecondary={false}
+                                  onClickPrimary={[Function]}
+                                  shouldStretchButtons={false}
+                                  textPrimary="Close"
+                                  textSecondary=""
+                                  withFooter={true}
+                                >
+                                  <Styled(styled.div)
+                                    stretch={false}
+                                  >
+                                    <div
+                                      className="c4 c9"
+                                    >
+                                      <Styled(Component)
+                                        color="primary"
+                                        disabled={false}
+                                        isLoading={false}
+                                        onClick={[Function]}
                                       >
-                                        <ModalHeader
-                                          onClickClose={[Function]}
-                                          textTitle="Action Action Action"
-                                          withHeader={true}
+                                        <ForwardRef
+                                          className=""
+                                          color="primary"
+                                          disabled={false}
+                                          isLoading={false}
+                                          onClick={[Function]}
                                         >
-                                          <Styled(styled.div)>
-                                            <div
-                                              className="c4 c5"
+                                          <Button
+                                            className=""
+                                            color="primary"
+                                            disabled={false}
+                                            forwardRef={null}
+                                            isLoading={false}
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(Button))
+                                              className="makeStyles-containedPrimary-13 "
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <styled.h1>
-                                                <h1
-                                                  className="c6"
-                                                >
-                                                  Action Action Action
-                                                </h1>
-                                              </styled.h1>
-                                              <styled.button
+                                              <ForwardRef(Button)
+                                                className="makeStyles-containedPrimary-13 "
+                                                classes={
+                                                  Object {
+                                                    "colorInherit": "MuiButton-colorInherit",
+                                                    "contained": "MuiButton-contained",
+                                                    "containedPrimary": "MuiButton-containedPrimary",
+                                                    "containedSecondary": "MuiButton-containedSecondary",
+                                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                    "disableElevation": "MuiButton-disableElevation",
+                                                    "disabled": "Mui-disabled",
+                                                    "endIcon": "MuiButton-endIcon",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "fullWidth": "MuiButton-fullWidth",
+                                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                    "label": "MuiButton-label",
+                                                    "outlined": "MuiButton-outlined",
+                                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                    "root": "MuiButton-root",
+                                                    "sizeLarge": "MuiButton-sizeLarge",
+                                                    "sizeSmall": "MuiButton-sizeSmall",
+                                                    "startIcon": "MuiButton-startIcon",
+                                                    "text": "MuiButton-text",
+                                                    "textPrimary": "MuiButton-textPrimary",
+                                                    "textSecondary": "MuiButton-textSecondary",
+                                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                                    "textSizeSmall": "MuiButton-textSizeSmall",
+                                                  }
+                                                }
+                                                color="default"
+                                                disableElevation={false}
+                                                disableRipple={true}
+                                                disabled={false}
                                                 onClick={[Function]}
+                                                variant="contained"
                                               >
-                                                <button
-                                                  className="c7"
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                  component="button"
+                                                  disableRipple={true}
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <FontAwesomeIcon
-                                                    border={false}
-                                                    className=""
-                                                    fixedWidth={false}
-                                                    flip={null}
-                                                    icon={
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                    classes={
                                                       Object {
-                                                        "icon": Array [
-                                                          320,
-                                                          512,
-                                                          Array [],
-                                                          "f00d",
-                                                          "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                        ],
-                                                        "iconName": "times",
-                                                        "prefix": "fal",
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
                                                       }
                                                     }
-                                                    inverse={false}
-                                                    listItem={false}
-                                                    mask={null}
-                                                    pull={null}
-                                                    pulse={false}
-                                                    rotation={null}
-                                                    size="lg"
-                                                    spin={false}
-                                                    swapOpacity={false}
-                                                    symbol={false}
-                                                    title=""
-                                                    transform={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                      data-icon="times"
-                                                      data-prefix="fal"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={Object {}}
-                                                      viewBox="0 0 320 512"
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                        fill="currentColor"
-                                                        style={Object {}}
-                                                      />
-                                                    </svg>
-                                                  </FontAwesomeIcon>
-                                                </button>
-                                              </styled.button>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalHeader>
-                                        <ModalBody
-                                          viewportScrolling={false}
-                                        >
-                                          <Styled(styled.div)
-                                            viewportScrolling={false}
-                                          >
-                                            <div
-                                              className="c4 c8"
-                                            >
-                                              <span>
-                                                Success! The action has been taken.
-                                              </span>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalBody>
-                                        <ModalFooter
-                                          isDisabledPrimary={false}
-                                          isDisabledSecondary={false}
-                                          isPendingPrimary={false}
-                                          isPendingSecondary={false}
-                                          onClickPrimary={[Function]}
-                                          shouldStretchButtons={false}
-                                          textPrimary="Close"
-                                          textSecondary=""
-                                          withFooter={true}
-                                        >
-                                          <Styled(styled.div)
-                                            stretch={false}
-                                          >
-                                            <div
-                                              className="c4 c9"
-                                            >
-                                              <Styled(Component)
-                                                color="primary"
-                                                disabled={false}
-                                                isLoading={false}
-                                                onClick={[Function]}
-                                              >
-                                                <ForwardRef
-                                                  className=""
-                                                  color="primary"
-                                                  disabled={false}
-                                                  isLoading={false}
-                                                  onClick={[Function]}
-                                                >
-                                                  <Button
-                                                    className=""
-                                                    color="primary"
+                                                    component="button"
+                                                    disableRipple={true}
                                                     disabled={false}
-                                                    forwardRef={null}
-                                                    isLoading={false}
+                                                    focusRipple={true}
+                                                    focusVisibleClassName="Mui-focusVisible"
                                                     onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <WithStyles(ForwardRef(Button))
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
+                                                    <button
+                                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
                                                       disabled={false}
+                                                      onBlur={[Function]}
                                                       onClick={[Function]}
-                                                      variant="contained"
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      tabIndex={0}
+                                                      type="button"
                                                     >
-                                                      <ForwardRef(Button)
-                                                        className="makeStyles-containedPrimary-13 "
-                                                        classes={
-                                                          Object {
-                                                            "colorInherit": "MuiButton-colorInherit",
-                                                            "contained": "MuiButton-contained",
-                                                            "containedPrimary": "MuiButton-containedPrimary",
-                                                            "containedSecondary": "MuiButton-containedSecondary",
-                                                            "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                            "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                            "disableElevation": "MuiButton-disableElevation",
-                                                            "disabled": "Mui-disabled",
-                                                            "endIcon": "MuiButton-endIcon",
-                                                            "focusVisible": "Mui-focusVisible",
-                                                            "fullWidth": "MuiButton-fullWidth",
-                                                            "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                            "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                            "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                            "label": "MuiButton-label",
-                                                            "outlined": "MuiButton-outlined",
-                                                            "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                            "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                            "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                            "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                            "root": "MuiButton-root",
-                                                            "sizeLarge": "MuiButton-sizeLarge",
-                                                            "sizeSmall": "MuiButton-sizeSmall",
-                                                            "startIcon": "MuiButton-startIcon",
-                                                            "text": "MuiButton-text",
-                                                            "textPrimary": "MuiButton-textPrimary",
-                                                            "textSecondary": "MuiButton-textSecondary",
-                                                            "textSizeLarge": "MuiButton-textSizeLarge",
-                                                            "textSizeSmall": "MuiButton-textSizeSmall",
-                                                          }
-                                                        }
-                                                        color="default"
-                                                        disableElevation={false}
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        onClick={[Function]}
-                                                        variant="contained"
+                                                      <span
+                                                        className="MuiButton-label"
                                                       >
-                                                        <WithStyles(ForwardRef(ButtonBase))
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <ForwardRef(ButtonBase)
-                                                            className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                            classes={
-                                                              Object {
-                                                                "disabled": "Mui-disabled",
-                                                                "focusVisible": "Mui-focusVisible",
-                                                                "root": "MuiButtonBase-root",
-                                                              }
-                                                            }
-                                                            component="button"
-                                                            disableRipple={true}
-                                                            disabled={false}
-                                                            focusRipple={true}
-                                                            focusVisibleClassName="Mui-focusVisible"
-                                                            onClick={[Function]}
-                                                            type="button"
-                                                          >
-                                                            <button
-                                                              className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                              disabled={false}
-                                                              onBlur={[Function]}
-                                                              onClick={[Function]}
-                                                              onDragLeave={[Function]}
-                                                              onFocus={[Function]}
-                                                              onKeyDown={[Function]}
-                                                              onKeyUp={[Function]}
-                                                              onMouseDown={[Function]}
-                                                              onMouseLeave={[Function]}
-                                                              onMouseUp={[Function]}
-                                                              onTouchEnd={[Function]}
-                                                              onTouchMove={[Function]}
-                                                              onTouchStart={[Function]}
-                                                              tabIndex={0}
-                                                              type="button"
-                                                            >
-                                                              <span
-                                                                className="MuiButton-label"
-                                                              >
-                                                                Close
-                                                              </span>
-                                                            </button>
-                                                          </ForwardRef(ButtonBase)>
-                                                        </WithStyles(ForwardRef(ButtonBase))>
-                                                      </ForwardRef(Button)>
-                                                    </WithStyles(ForwardRef(Button))>
-                                                  </Button>
-                                                </ForwardRef>
-                                              </Styled(Component)>
-                                            </div>
-                                          </Styled(styled.div)>
-                                        </ModalFooter>
-                                      </div>
-                                    </styled.div>
-                                  </div>
-                                </styled.div>
+                                                        Close
+                                                      </span>
+                                                    </button>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(Button)>
+                                            </WithStyles(ForwardRef(Button))>
+                                          </Button>
+                                        </ForwardRef>
+                                      </Styled(Component)>
+                                    </div>
+                                  </Styled(styled.div)>
+                                </ModalFooter>
                               </div>
-                            </OverlayInnerContainer>
+                            </styled.div>
                           </div>
-                        </OverlayOuterContainer>
-                      </TouchScrollable>
-                    </ScrollLock>
-                  </TouchProvider>
-                </SheetProvider>
-              </LockToggle>
+                        </styled.div>
+                      </div>
+                    </OverlayInnerContainer>
+                  </div>
+                </OverlayOuterContainer>
+              </TouchScrollable>
             </Portal>
           </Portal>
         </Transition>

--- a/src/modal/src/components/__snapshots__/Modal.test.js.snap
+++ b/src/modal/src/components/__snapshots__/Modal.test.js.snap
@@ -557,451 +557,431 @@ exports[`modal snapshots should match snapshot when isVisible="true" 1`] = `
               </div>
             }
           >
-            <LockToggle
-              accountForScrollbars={true}
-              isActive={true}
-            >
-              <SheetProvider
-                accountForScrollbars={true}
-                isActive={true}
+            <TouchScrollable>
+              <OverlayOuterContainer
+                transparent={false}
               >
-                <TouchProvider
-                  accountForScrollbars={true}
-                  isActive={true}
+                <div
+                  className="c0"
                 >
-                  <ScrollLock
-                    accountForScrollbars={true}
-                    isActive={true}
+                  <OverlayInnerContainer
+                    isScrollable={false}
+                    onClick={[Function]}
                   >
-                    <TouchScrollable>
-                      <OverlayOuterContainer
-                        transparent={false}
+                    <div
+                      className="c1"
+                      onClick={[Function]}
+                    >
+                      <styled.div
+                        onClick={[Function]}
+                        viewportScrolling={false}
                       >
                         <div
-                          className="c0"
+                          className="c2"
+                          onClick={[Function]}
                         >
-                          <OverlayInnerContainer
-                            isScrollable={false}
-                            onClick={[Function]}
+                          <styled.div
+                            center={true}
+                            viewportScrolling={false}
                           >
                             <div
-                              className="c1"
-                              onClick={[Function]}
+                              className="c3"
                             >
-                              <styled.div
-                                onClick={[Function]}
+                              <ModalHeader
+                                onClickClose={[Function]}
+                                textTitle="Title"
+                                withHeader={true}
+                              >
+                                <Styled(styled.div)>
+                                  <div
+                                    className="c4 c5"
+                                  >
+                                    <styled.h1>
+                                      <h1
+                                        className="c6"
+                                      >
+                                        Title
+                                      </h1>
+                                    </styled.h1>
+                                    <styled.button
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="c7"
+                                        onClick={[Function]}
+                                      >
+                                        <FontAwesomeIcon
+                                          border={false}
+                                          className=""
+                                          fixedWidth={false}
+                                          flip={null}
+                                          icon={
+                                            Object {
+                                              "icon": Array [
+                                                320,
+                                                512,
+                                                Array [],
+                                                "f00d",
+                                                "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
+                                              ],
+                                              "iconName": "times",
+                                              "prefix": "fal",
+                                            }
+                                          }
+                                          inverse={false}
+                                          listItem={false}
+                                          mask={null}
+                                          pull={null}
+                                          pulse={false}
+                                          rotation={null}
+                                          size="lg"
+                                          spin={false}
+                                          swapOpacity={false}
+                                          symbol={false}
+                                          title=""
+                                          transform={null}
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            className="svg-inline--fa fa-times fa-w-10 fa-lg "
+                                            data-icon="times"
+                                            data-prefix="fal"
+                                            focusable="false"
+                                            role="img"
+                                            style={Object {}}
+                                            viewBox="0 0 320 512"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
+                                              fill="currentColor"
+                                              style={Object {}}
+                                            />
+                                          </svg>
+                                        </FontAwesomeIcon>
+                                      </button>
+                                    </styled.button>
+                                  </div>
+                                </Styled(styled.div)>
+                              </ModalHeader>
+                              <ModalBody
                                 viewportScrolling={false}
                               >
-                                <div
-                                  className="c2"
-                                  onClick={[Function]}
+                                <Styled(styled.div)
+                                  viewportScrolling={false}
                                 >
-                                  <styled.div
-                                    center={true}
-                                    viewportScrolling={false}
+                                  <div
+                                    className="c4 c8"
                                   >
-                                    <div
-                                      className="c3"
+                                    <span>
+                                      hello
+                                    </span>
+                                  </div>
+                                </Styled(styled.div)>
+                              </ModalBody>
+                              <ModalFooter
+                                isDisabledPrimary={false}
+                                isDisabledSecondary={false}
+                                isPendingPrimary={false}
+                                isPendingSecondary={false}
+                                onClickPrimary={[Function]}
+                                onClickSecondary={[Function]}
+                                shouldStretchButtons={false}
+                                textPrimary="Confirm"
+                                textSecondary="Cancel"
+                                withFooter={true}
+                              >
+                                <Styled(styled.div)
+                                  stretch={false}
+                                >
+                                  <div
+                                    className="c4 c9"
+                                  >
+                                    <Styled(Component)
+                                      color="primary"
+                                      disabled={false}
+                                      isLoading={false}
+                                      onClick={[Function]}
                                     >
-                                      <ModalHeader
-                                        onClickClose={[Function]}
-                                        textTitle="Title"
-                                        withHeader={true}
+                                      <ForwardRef
+                                        className=""
+                                        color="primary"
+                                        disabled={false}
+                                        isLoading={false}
+                                        onClick={[Function]}
                                       >
-                                        <Styled(styled.div)>
-                                          <div
-                                            className="c4 c5"
+                                        <Button
+                                          className=""
+                                          color="primary"
+                                          disabled={false}
+                                          forwardRef={null}
+                                          isLoading={false}
+                                          onClick={[Function]}
+                                        >
+                                          <WithStyles(ForwardRef(Button))
+                                            className="makeStyles-containedPrimary-13 "
+                                            color="default"
+                                            disableElevation={false}
+                                            disableRipple={true}
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            variant="contained"
                                           >
-                                            <styled.h1>
-                                              <h1
-                                                className="c6"
-                                              >
-                                                Title
-                                              </h1>
-                                            </styled.h1>
-                                            <styled.button
+                                            <ForwardRef(Button)
+                                              className="makeStyles-containedPrimary-13 "
+                                              classes={
+                                                Object {
+                                                  "colorInherit": "MuiButton-colorInherit",
+                                                  "contained": "MuiButton-contained",
+                                                  "containedPrimary": "MuiButton-containedPrimary",
+                                                  "containedSecondary": "MuiButton-containedSecondary",
+                                                  "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                  "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                  "disableElevation": "MuiButton-disableElevation",
+                                                  "disabled": "Mui-disabled",
+                                                  "endIcon": "MuiButton-endIcon",
+                                                  "focusVisible": "Mui-focusVisible",
+                                                  "fullWidth": "MuiButton-fullWidth",
+                                                  "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                  "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                  "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                  "label": "MuiButton-label",
+                                                  "outlined": "MuiButton-outlined",
+                                                  "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                  "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                  "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                  "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                  "root": "MuiButton-root",
+                                                  "sizeLarge": "MuiButton-sizeLarge",
+                                                  "sizeSmall": "MuiButton-sizeSmall",
+                                                  "startIcon": "MuiButton-startIcon",
+                                                  "text": "MuiButton-text",
+                                                  "textPrimary": "MuiButton-textPrimary",
+                                                  "textSecondary": "MuiButton-textSecondary",
+                                                  "textSizeLarge": "MuiButton-textSizeLarge",
+                                                  "textSizeSmall": "MuiButton-textSizeSmall",
+                                                }
+                                              }
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
+                                              disabled={false}
                                               onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <button
-                                                className="c7"
+                                              <WithStyles(ForwardRef(ButtonBase))
+                                                className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                component="button"
+                                                disableRipple={true}
+                                                disabled={false}
+                                                focusRipple={true}
+                                                focusVisibleClassName="Mui-focusVisible"
                                                 onClick={[Function]}
+                                                type="button"
                                               >
-                                                <FontAwesomeIcon
-                                                  border={false}
-                                                  className=""
-                                                  fixedWidth={false}
-                                                  flip={null}
-                                                  icon={
+                                                <ForwardRef(ButtonBase)
+                                                  className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
+                                                  classes={
                                                     Object {
-                                                      "icon": Array [
-                                                        320,
-                                                        512,
-                                                        Array [],
-                                                        "f00d",
-                                                        "M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z",
-                                                      ],
-                                                      "iconName": "times",
-                                                      "prefix": "fal",
+                                                      "disabled": "Mui-disabled",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "root": "MuiButtonBase-root",
                                                     }
                                                   }
-                                                  inverse={false}
-                                                  listItem={false}
-                                                  mask={null}
-                                                  pull={null}
-                                                  pulse={false}
-                                                  rotation={null}
-                                                  size="lg"
-                                                  spin={false}
-                                                  swapOpacity={false}
-                                                  symbol={false}
-                                                  title=""
-                                                  transform={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden="true"
-                                                    className="svg-inline--fa fa-times fa-w-10 fa-lg "
-                                                    data-icon="times"
-                                                    data-prefix="fal"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={Object {}}
-                                                    viewBox="0 0 320 512"
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"
-                                                      fill="currentColor"
-                                                      style={Object {}}
-                                                    />
-                                                  </svg>
-                                                </FontAwesomeIcon>
-                                              </button>
-                                            </styled.button>
-                                          </div>
-                                        </Styled(styled.div)>
-                                      </ModalHeader>
-                                      <ModalBody
-                                        viewportScrolling={false}
-                                      >
-                                        <Styled(styled.div)
-                                          viewportScrolling={false}
-                                        >
-                                          <div
-                                            className="c4 c8"
-                                          >
-                                            <span>
-                                              hello
-                                            </span>
-                                          </div>
-                                        </Styled(styled.div)>
-                                      </ModalBody>
-                                      <ModalFooter
-                                        isDisabledPrimary={false}
-                                        isDisabledSecondary={false}
-                                        isPendingPrimary={false}
-                                        isPendingSecondary={false}
-                                        onClickPrimary={[Function]}
-                                        onClickSecondary={[Function]}
-                                        shouldStretchButtons={false}
-                                        textPrimary="Confirm"
-                                        textSecondary="Cancel"
-                                        withFooter={true}
-                                      >
-                                        <Styled(styled.div)
-                                          stretch={false}
-                                        >
-                                          <div
-                                            className="c4 c9"
-                                          >
-                                            <Styled(Component)
-                                              color="primary"
-                                              disabled={false}
-                                              isLoading={false}
-                                              onClick={[Function]}
-                                            >
-                                              <ForwardRef
-                                                className=""
-                                                color="primary"
-                                                disabled={false}
-                                                isLoading={false}
-                                                onClick={[Function]}
-                                              >
-                                                <Button
-                                                  className=""
-                                                  color="primary"
+                                                  component="button"
+                                                  disableRipple={true}
                                                   disabled={false}
-                                                  forwardRef={null}
-                                                  isLoading={false}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <WithStyles(ForwardRef(Button))
-                                                    className="makeStyles-containedPrimary-13 "
-                                                    color="default"
-                                                    disableElevation={false}
-                                                    disableRipple={true}
+                                                  <button
+                                                    className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
                                                     disabled={false}
+                                                    onBlur={[Function]}
                                                     onClick={[Function]}
-                                                    variant="contained"
+                                                    onDragLeave={[Function]}
+                                                    onFocus={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    onMouseDown={[Function]}
+                                                    onMouseLeave={[Function]}
+                                                    onMouseUp={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                    onTouchMove={[Function]}
+                                                    onTouchStart={[Function]}
+                                                    tabIndex={0}
+                                                    type="button"
                                                   >
-                                                    <ForwardRef(Button)
-                                                      className="makeStyles-containedPrimary-13 "
-                                                      classes={
-                                                        Object {
-                                                          "colorInherit": "MuiButton-colorInherit",
-                                                          "contained": "MuiButton-contained",
-                                                          "containedPrimary": "MuiButton-containedPrimary",
-                                                          "containedSecondary": "MuiButton-containedSecondary",
-                                                          "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                          "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                          "disableElevation": "MuiButton-disableElevation",
-                                                          "disabled": "Mui-disabled",
-                                                          "endIcon": "MuiButton-endIcon",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "fullWidth": "MuiButton-fullWidth",
-                                                          "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                          "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                          "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                          "label": "MuiButton-label",
-                                                          "outlined": "MuiButton-outlined",
-                                                          "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                          "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                          "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                          "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                          "root": "MuiButton-root",
-                                                          "sizeLarge": "MuiButton-sizeLarge",
-                                                          "sizeSmall": "MuiButton-sizeSmall",
-                                                          "startIcon": "MuiButton-startIcon",
-                                                          "text": "MuiButton-text",
-                                                          "textPrimary": "MuiButton-textPrimary",
-                                                          "textSecondary": "MuiButton-textSecondary",
-                                                          "textSizeLarge": "MuiButton-textSizeLarge",
-                                                          "textSizeSmall": "MuiButton-textSizeSmall",
-                                                        }
-                                                      }
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
-                                                      disabled={false}
-                                                      onClick={[Function]}
-                                                      variant="contained"
+                                                    <span
+                                                      className="MuiButton-label"
                                                     >
-                                                      <WithStyles(ForwardRef(ButtonBase))
-                                                        className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                        component="button"
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        focusRipple={true}
-                                                        focusVisibleClassName="Mui-focusVisible"
-                                                        onClick={[Function]}
-                                                        type="button"
-                                                      >
-                                                        <ForwardRef(ButtonBase)
-                                                          className="MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                          classes={
-                                                            Object {
-                                                              "disabled": "Mui-disabled",
-                                                              "focusVisible": "Mui-focusVisible",
-                                                              "root": "MuiButtonBase-root",
-                                                            }
-                                                          }
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <button
-                                                            className="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-containedPrimary-13 "
-                                                            disabled={false}
-                                                            onBlur={[Function]}
-                                                            onClick={[Function]}
-                                                            onDragLeave={[Function]}
-                                                            onFocus={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onKeyUp={[Function]}
-                                                            onMouseDown={[Function]}
-                                                            onMouseLeave={[Function]}
-                                                            onMouseUp={[Function]}
-                                                            onTouchEnd={[Function]}
-                                                            onTouchMove={[Function]}
-                                                            onTouchStart={[Function]}
-                                                            tabIndex={0}
-                                                            type="button"
-                                                          >
-                                                            <span
-                                                              className="MuiButton-label"
-                                                            >
-                                                              Confirm
-                                                            </span>
-                                                          </button>
-                                                        </ForwardRef(ButtonBase)>
-                                                      </WithStyles(ForwardRef(ButtonBase))>
-                                                    </ForwardRef(Button)>
-                                                  </WithStyles(ForwardRef(Button))>
-                                                </Button>
-                                              </ForwardRef>
-                                            </Styled(Component)>
-                                            <Styled(Component)
+                                                      Confirm
+                                                    </span>
+                                                  </button>
+                                                </ForwardRef(ButtonBase)>
+                                              </WithStyles(ForwardRef(ButtonBase))>
+                                            </ForwardRef(Button)>
+                                          </WithStyles(ForwardRef(Button))>
+                                        </Button>
+                                      </ForwardRef>
+                                    </Styled(Component)>
+                                    <Styled(Component)
+                                      disabled={false}
+                                      id="secondary"
+                                      isLoading={false}
+                                      name="secondary"
+                                      onClick={[Function]}
+                                    >
+                                      <ForwardRef
+                                        className=""
+                                        disabled={false}
+                                        id="secondary"
+                                        isLoading={false}
+                                        name="secondary"
+                                        onClick={[Function]}
+                                      >
+                                        <Button
+                                          className=""
+                                          disabled={false}
+                                          forwardRef={null}
+                                          id="secondary"
+                                          isLoading={false}
+                                          name="secondary"
+                                          onClick={[Function]}
+                                        >
+                                          <WithStyles(ForwardRef(Button))
+                                            className=""
+                                            color="default"
+                                            disableElevation={false}
+                                            disableRipple={true}
+                                            disabled={false}
+                                            id="secondary"
+                                            name="secondary"
+                                            onClick={[Function]}
+                                            variant="contained"
+                                          >
+                                            <ForwardRef(Button)
+                                              className=""
+                                              classes={
+                                                Object {
+                                                  "colorInherit": "MuiButton-colorInherit",
+                                                  "contained": "MuiButton-contained",
+                                                  "containedPrimary": "MuiButton-containedPrimary",
+                                                  "containedSecondary": "MuiButton-containedSecondary",
+                                                  "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                                  "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                                  "disableElevation": "MuiButton-disableElevation",
+                                                  "disabled": "Mui-disabled",
+                                                  "endIcon": "MuiButton-endIcon",
+                                                  "focusVisible": "Mui-focusVisible",
+                                                  "fullWidth": "MuiButton-fullWidth",
+                                                  "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                                  "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                                  "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                                  "label": "MuiButton-label",
+                                                  "outlined": "MuiButton-outlined",
+                                                  "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                                  "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                                  "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                                  "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                                  "root": "MuiButton-root",
+                                                  "sizeLarge": "MuiButton-sizeLarge",
+                                                  "sizeSmall": "MuiButton-sizeSmall",
+                                                  "startIcon": "MuiButton-startIcon",
+                                                  "text": "MuiButton-text",
+                                                  "textPrimary": "MuiButton-textPrimary",
+                                                  "textSecondary": "MuiButton-textSecondary",
+                                                  "textSizeLarge": "MuiButton-textSizeLarge",
+                                                  "textSizeSmall": "MuiButton-textSizeSmall",
+                                                }
+                                              }
+                                              color="default"
+                                              disableElevation={false}
+                                              disableRipple={true}
                                               disabled={false}
                                               id="secondary"
-                                              isLoading={false}
                                               name="secondary"
                                               onClick={[Function]}
+                                              variant="contained"
                                             >
-                                              <ForwardRef
-                                                className=""
+                                              <WithStyles(ForwardRef(ButtonBase))
+                                                className="MuiButton-root MuiButton-contained "
+                                                component="button"
+                                                disableRipple={true}
                                                 disabled={false}
+                                                focusRipple={true}
+                                                focusVisibleClassName="Mui-focusVisible"
                                                 id="secondary"
-                                                isLoading={false}
                                                 name="secondary"
                                                 onClick={[Function]}
+                                                type="button"
                                               >
-                                                <Button
-                                                  className=""
+                                                <ForwardRef(ButtonBase)
+                                                  className="MuiButton-root MuiButton-contained "
+                                                  classes={
+                                                    Object {
+                                                      "disabled": "Mui-disabled",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "root": "MuiButtonBase-root",
+                                                    }
+                                                  }
+                                                  component="button"
+                                                  disableRipple={true}
                                                   disabled={false}
-                                                  forwardRef={null}
+                                                  focusRipple={true}
+                                                  focusVisibleClassName="Mui-focusVisible"
                                                   id="secondary"
-                                                  isLoading={false}
                                                   name="secondary"
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <WithStyles(ForwardRef(Button))
-                                                    className=""
-                                                    color="default"
-                                                    disableElevation={false}
-                                                    disableRipple={true}
+                                                  <button
+                                                    className="MuiButtonBase-root MuiButton-root MuiButton-contained "
                                                     disabled={false}
                                                     id="secondary"
                                                     name="secondary"
+                                                    onBlur={[Function]}
                                                     onClick={[Function]}
-                                                    variant="contained"
+                                                    onDragLeave={[Function]}
+                                                    onFocus={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    onMouseDown={[Function]}
+                                                    onMouseLeave={[Function]}
+                                                    onMouseUp={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                    onTouchMove={[Function]}
+                                                    onTouchStart={[Function]}
+                                                    tabIndex={0}
+                                                    type="button"
                                                   >
-                                                    <ForwardRef(Button)
-                                                      className=""
-                                                      classes={
-                                                        Object {
-                                                          "colorInherit": "MuiButton-colorInherit",
-                                                          "contained": "MuiButton-contained",
-                                                          "containedPrimary": "MuiButton-containedPrimary",
-                                                          "containedSecondary": "MuiButton-containedSecondary",
-                                                          "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                                          "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                                          "disableElevation": "MuiButton-disableElevation",
-                                                          "disabled": "Mui-disabled",
-                                                          "endIcon": "MuiButton-endIcon",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "fullWidth": "MuiButton-fullWidth",
-                                                          "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                                          "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                                          "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                                          "label": "MuiButton-label",
-                                                          "outlined": "MuiButton-outlined",
-                                                          "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                                          "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                                          "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                                          "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                                          "root": "MuiButton-root",
-                                                          "sizeLarge": "MuiButton-sizeLarge",
-                                                          "sizeSmall": "MuiButton-sizeSmall",
-                                                          "startIcon": "MuiButton-startIcon",
-                                                          "text": "MuiButton-text",
-                                                          "textPrimary": "MuiButton-textPrimary",
-                                                          "textSecondary": "MuiButton-textSecondary",
-                                                          "textSizeLarge": "MuiButton-textSizeLarge",
-                                                          "textSizeSmall": "MuiButton-textSizeSmall",
-                                                        }
-                                                      }
-                                                      color="default"
-                                                      disableElevation={false}
-                                                      disableRipple={true}
-                                                      disabled={false}
-                                                      id="secondary"
-                                                      name="secondary"
-                                                      onClick={[Function]}
-                                                      variant="contained"
+                                                    <span
+                                                      className="MuiButton-label"
                                                     >
-                                                      <WithStyles(ForwardRef(ButtonBase))
-                                                        className="MuiButton-root MuiButton-contained "
-                                                        component="button"
-                                                        disableRipple={true}
-                                                        disabled={false}
-                                                        focusRipple={true}
-                                                        focusVisibleClassName="Mui-focusVisible"
-                                                        id="secondary"
-                                                        name="secondary"
-                                                        onClick={[Function]}
-                                                        type="button"
-                                                      >
-                                                        <ForwardRef(ButtonBase)
-                                                          className="MuiButton-root MuiButton-contained "
-                                                          classes={
-                                                            Object {
-                                                              "disabled": "Mui-disabled",
-                                                              "focusVisible": "Mui-focusVisible",
-                                                              "root": "MuiButtonBase-root",
-                                                            }
-                                                          }
-                                                          component="button"
-                                                          disableRipple={true}
-                                                          disabled={false}
-                                                          focusRipple={true}
-                                                          focusVisibleClassName="Mui-focusVisible"
-                                                          id="secondary"
-                                                          name="secondary"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <button
-                                                            className="MuiButtonBase-root MuiButton-root MuiButton-contained "
-                                                            disabled={false}
-                                                            id="secondary"
-                                                            name="secondary"
-                                                            onBlur={[Function]}
-                                                            onClick={[Function]}
-                                                            onDragLeave={[Function]}
-                                                            onFocus={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onKeyUp={[Function]}
-                                                            onMouseDown={[Function]}
-                                                            onMouseLeave={[Function]}
-                                                            onMouseUp={[Function]}
-                                                            onTouchEnd={[Function]}
-                                                            onTouchMove={[Function]}
-                                                            onTouchStart={[Function]}
-                                                            tabIndex={0}
-                                                            type="button"
-                                                          >
-                                                            <span
-                                                              className="MuiButton-label"
-                                                            >
-                                                              Cancel
-                                                            </span>
-                                                          </button>
-                                                        </ForwardRef(ButtonBase)>
-                                                      </WithStyles(ForwardRef(ButtonBase))>
-                                                    </ForwardRef(Button)>
-                                                  </WithStyles(ForwardRef(Button))>
-                                                </Button>
-                                              </ForwardRef>
-                                            </Styled(Component)>
-                                          </div>
-                                        </Styled(styled.div)>
-                                      </ModalFooter>
-                                    </div>
-                                  </styled.div>
-                                </div>
-                              </styled.div>
+                                                      Cancel
+                                                    </span>
+                                                  </button>
+                                                </ForwardRef(ButtonBase)>
+                                              </WithStyles(ForwardRef(ButtonBase))>
+                                            </ForwardRef(Button)>
+                                          </WithStyles(ForwardRef(Button))>
+                                        </Button>
+                                      </ForwardRef>
+                                    </Styled(Component)>
+                                  </div>
+                                </Styled(styled.div)>
+                              </ModalFooter>
                             </div>
-                          </OverlayInnerContainer>
+                          </styled.div>
                         </div>
-                      </OverlayOuterContainer>
-                    </TouchScrollable>
-                  </ScrollLock>
-                </TouchProvider>
-              </SheetProvider>
-            </LockToggle>
+                      </styled.div>
+                    </div>
+                  </OverlayInnerContainer>
+                </div>
+              </OverlayOuterContainer>
+            </TouchScrollable>
           </Portal>
         </Portal>
       </Transition>

--- a/src/overlay/src/components/Overlay.js
+++ b/src/overlay/src/components/Overlay.js
@@ -6,12 +6,13 @@ import { Component } from 'react';
 import type { Node } from 'react';
 
 import PropTypes from 'prop-types';
-import ScrollLock from 'react-scrolllock';
 import isFunction from 'lodash/isFunction';
+import { TouchScrollable } from 'react-scrolllock';
 import { CSSTransition } from 'react-transition-group';
 
-import Portal from '../../../portal';
 import { OverlayInnerContainer, OverlayOuterContainer } from './styled/StyledOverlayComponents';
+
+import Portal from '../../../portal';
 
 type Props = {
   children ? :Node;
@@ -80,13 +81,13 @@ export default class Overlay extends Component<Props> {
           timeout={200}
           classNames="luk-fade">
         <Portal>
-          <ScrollLock>
+          <TouchScrollable>
             <OverlayOuterContainer transparent={transparent}>
               <OverlayInnerContainer isScrollable={isScrollable} onClick={this.handleOnClick}>
                 { children }
               </OverlayInnerContainer>
             </OverlayOuterContainer>
-          </ScrollLock>
+          </TouchScrollable>
         </Portal>
       </CSSTransition>
     );

--- a/src/overlay/src/components/__snapshots__/Overlay.test.js.snap
+++ b/src/overlay/src/components/__snapshots__/Overlay.test.js.snap
@@ -84,49 +84,29 @@ exports[`overlay snapshots should match snapshot when isVisible="true" 1`] = `
             </div>
           }
         >
-          <LockToggle
-            accountForScrollbars={true}
-            isActive={true}
-          >
-            <SheetProvider
-              accountForScrollbars={true}
-              isActive={true}
+          <TouchScrollable>
+            <OverlayOuterContainer
+              transparent={false}
             >
-              <TouchProvider
-                accountForScrollbars={true}
-                isActive={true}
+              <div
+                className="kcBBUu"
               >
-                <ScrollLock
-                  accountForScrollbars={true}
-                  isActive={true}
+                <OverlayInnerContainer
+                  isScrollable={false}
+                  onClick={[Function]}
                 >
-                  <TouchScrollable>
-                    <OverlayOuterContainer
-                      transparent={false}
-                    >
-                      <div
-                        className="kcBBUu"
-                      >
-                        <OverlayInnerContainer
-                          isScrollable={false}
-                          onClick={[Function]}
-                        >
-                          <div
-                            className="huVzSq"
-                            onClick={[Function]}
-                          >
-                            <span>
-                              hello
-                            </span>
-                          </div>
-                        </OverlayInnerContainer>
-                      </div>
-                    </OverlayOuterContainer>
-                  </TouchScrollable>
-                </ScrollLock>
-              </TouchProvider>
-            </SheetProvider>
-          </LockToggle>
+                  <div
+                    className="huVzSq"
+                    onClick={[Function]}
+                  >
+                    <span>
+                      hello
+                    </span>
+                  </div>
+                </OverlayInnerContainer>
+              </div>
+            </OverlayOuterContainer>
+          </TouchScrollable>
         </Portal>
       </Portal>
     </Transition>


### PR DESCRIPTION
`ScrollLock` was being used in the `Overlay` component, which was preventing scrolling within the drawer on mobile. The intended use was to keep the background from scrolling. `TouchScrollable` is what should be used here—it allows for mobile scrolling of the drawer and prevents background scrolling:
https://npm.io/package/react-scrolllock

I symlinked LUK with the website to test this, and it works as expected.